### PR TITLE
Avoid compiler warnings for signed vs unsigned integer comparisons

### DIFF
--- a/highway_tree_hash.cc
+++ b/highway_tree_hash.cc
@@ -158,7 +158,7 @@ uint64_t HighwayTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   const size_t remainder = size & (kPacketSize - 1);
   const size_t truncated_size = size - remainder;
   const uint64_t* packets = reinterpret_cast<const uint64_t*>(bytes);
-  for (int i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
+  for (size_t i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
     const V4x64U packet = LoadU(packets + i);
     state.Update(packet);
   }

--- a/scalar_highway_tree_hash.cc
+++ b/scalar_highway_tree_hash.cc
@@ -113,7 +113,7 @@ uint64_t ScalarHighwayTreeHash(const Lanes& key, const uint8_t* bytes,
   const size_t remainder = size & (kPacketSize - 1);
   const size_t truncated_size = size - remainder;
   const uint64_t* packets = reinterpret_cast<const uint64_t*>(bytes);
-  for (int i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
+  for (size_t i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
     state.Update(packets + i);
   }
 
@@ -121,7 +121,7 @@ uint64_t ScalarHighwayTreeHash(const Lanes& key, const uint8_t* bytes,
   const size_t remainder_mod4 = remainder & 3;
   uint32_t packet4 = static_cast<uint32_t>(size) << 24;
   const uint8_t* final_bytes = bytes + size - remainder_mod4;
-  for (int i = 0; i < remainder_mod4; ++i) {
+  for (size_t i = 0; i < remainder_mod4; ++i) {
     packet4 += static_cast<uint32_t>(final_bytes[i]) << (i * 8);
   }
 

--- a/scalar_sip_tree_hash.cc
+++ b/scalar_sip_tree_hash.cc
@@ -111,7 +111,7 @@ uint64_t ScalarSipTreeHash(const Lanes& key,
   const size_t remainder = size & (kPacketSize - 1);
   const size_t truncated_size = size - remainder;
   const uint64_t* packets = reinterpret_cast<const uint64_t*>(bytes);
-  for (int i = 0; i < truncated_size / kPacketSize; ++i) {
+  for (size_t i = 0; i < truncated_size / kPacketSize; ++i) {
     for (int lane = 0; lane < kNumLanes; ++lane) {
       const uint64_t packet = *packets++;
       state[lane].Update(packet);
@@ -122,7 +122,7 @@ uint64_t ScalarSipTreeHash(const Lanes& key,
   const size_t remainder_mod4 = remainder & 3;
   uint32_t packet4 = remainder << 24;
   const uint8_t* final_bytes = bytes + size - remainder_mod4;
-  for (int i = 0; i < remainder_mod4; ++i) {
+  for (size_t i = 0; i < remainder_mod4; ++i) {
     packet4 += static_cast<uint32_t>(final_bytes[i]) << (i * 8);
   }
 

--- a/sip_tree_hash.cc
+++ b/sip_tree_hash.cc
@@ -164,7 +164,7 @@ uint64_t SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   const size_t remainder = size & (kPacketSize - 1);
   const size_t truncated_size = size - remainder;
   const uint64_t* packets = reinterpret_cast<const uint64_t*>(bytes);
-  for (int i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
+  for (size_t i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
     const V4x64U packet = LoadU(packets + i);
     state.Update(packet);
   }


### PR DESCRIPTION
There were multiple noisy warnings with clang++, g++, and icpc like this:

```
highway_tree_hash.cc: In function ‘uint64_t HighwayTreeHash(const uint64_t (&)[4], const uint8_t*, uint64_t)’:
highway_tree_hash.cc:161:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < truncated_size / sizeof(uint64_t); i += kNumLanes) {
                     ^
```

This quiets them.  