### PR TITLE
Add optional Makefile so bazel install is not required to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+CXXFLAGS := -g -std=c++11 -Wall -O3 -march=native
+
+OBJS := highway_tree_hash.o \
+	scalar_highway_tree_hash.o \
+	scalar_sip_tree_hash.o \
+	sip_hash.o \
+	sip_tree_hash.o
+
+MAIN := sip_hash_main
+
+all: $(MAIN)
+
+$(MAIN): $(OBJS) $(MAIN).cc
+	$(CXX) $(CXXFLAGS) $(OBJS) $(MAIN).cc -o $(MAIN)
+
+clean: 
+	$(RM) $(OBJS) $(MAIN)
+
+.PHONY: clean


### PR DESCRIPTION
Requiring Bazel makes it harder than necessary for outsiders to test this code.  Here's a simple Makefile that will allow compilation without it.  