### PR TITLE
Don't mangle names

### DIFF
--- a/highway_tree_hash.h
+++ b/highway_tree_hash.h
@@ -27,6 +27,7 @@
 // "size" is the number of bytes to hash; exactly that many bytes are read.
 //
 // Returns a 64-bit hash of the given data bytes.
+extern "C"
 uint64_t HighwayTreeHash(const uint64_t (&key)[4], const uint8_t* bytes,
                          const uint64_t size);
 

--- a/scalar_highway_tree_hash.h
+++ b/scalar_highway_tree_hash.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+extern "C"
 uint64_t ScalarHighwayTreeHash(const uint64_t (&key)[4], const uint8_t* bytes,
                                const uint64_t size);
 

--- a/scalar_sip_tree_hash.h
+++ b/scalar_sip_tree_hash.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+extern "C"
 uint64_t ScalarSipTreeHash(const uint64_t (&key)[4], const uint8_t* bytes,
                            const uint64_t size);
 

--- a/sip_hash.h
+++ b/sip_hash.h
@@ -32,9 +32,11 @@
 // "key" is a secret 128-bit key unknown to attackers.
 // "bytes" is the data to hash; ceil(size / 8) * 8 bytes are read.
 // Returns a 64-bit hash of the given data bytes.
+extern "C"
 uint64_t SipHash(const uint64_t key[2], const uint8_t* bytes,
                  const uint64_t size);
 
+extern "C"
 uint64_t ReduceSipTreeHash(const uint64_t key[2], const uint64_t hashes[4]);
 
 #endif  // #ifndef HIGHWAYHASH_SIP_HASH_H_

--- a/sip_tree_hash.h
+++ b/sip_tree_hash.h
@@ -33,6 +33,7 @@
 // "bytes" is the data to hash (possibly unaligned).
 // "size" is the number of bytes to hash; exactly that many bytes are read.
 // Returns a 64-bit hash of the given data bytes.
+extern "C"
 uint64_t SipTreeHash(const uint64_t (&key)[4], const uint8_t* bytes,
                      const uint64_t size);
 


### PR DESCRIPTION
This makes it easier to bind to highwayhash from other languages (C,
Rust, Python, ...) and from code with differing C++ implementations.