### PR TITLE
Runtime lookup for AVX2 instructions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,10 +10,20 @@ cc_library(
 )
 
 cc_library(
+    name = "sse41_sip_hash",
+    srcs = ["sse41_sip_hash.cc"],
+    hdrs = ["sse41_sip_hash.h"],
+    deps = [
+        ":vector",
+    ],
+)
+
+cc_library(
     name = "sip_hash",
     srcs = ["sip_hash.cc"],
     hdrs = ["sip_hash.h"],
     deps = [
+        ":sse41_sip_hash",
         ":vector",
     ],
 )
@@ -23,6 +33,7 @@ cc_library(
     srcs = ["sip_tree_hash.cc"],
     hdrs = ["sip_tree_hash.h"],
     deps = [
+        ":scalar_sip_tree_hash",
         ":sip_hash",
         ":vector",
     ],
@@ -43,6 +54,7 @@ cc_library(
     srcs = ["highway_tree_hash.cc"],
     hdrs = ["highway_tree_hash.h"],
     deps = [
+        ":scalar_highway_tree_hash",
         ":vector",
     ],
 )
@@ -68,5 +80,6 @@ cc_binary(
         ":scalar_sip_tree_hash",
         ":sip_hash",
         ":sip_tree_hash",
+        ":sse41_sip_hash",
     ],
 )

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS := -std=c++11 -O3 -mavx2 -Wall -DDEBUG
+CXXFLAGS := -std=c++11 -O2 -mavx2 -Wall -DDEBUG
 
 OBJS := highway_tree_hash.o \
 	scalar_highway_tree_hash.o \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ OBJS := highway_tree_hash.o \
 	scalar_highway_tree_hash.o \
 	scalar_sip_tree_hash.o \
 	sip_hash.o \
-	sip_tree_hash.o
+	sip_tree_hash.o \
+	sse41_sip_hash.o
 
 MAIN := sip_hash_main
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS := -std=c++11 -O3 -mavx2 -Wall
+CXXFLAGS := -std=c++11 -O3 -mavx2 -Wall -DDEBUG
 
 OBJS := highway_tree_hash.o \
 	scalar_highway_tree_hash.o \

--- a/highway_tree_hash.cc
+++ b/highway_tree_hash.cc
@@ -153,7 +153,7 @@ static INLINE V4x64U LoadFinalPacket32(const uint8_t* bytes,
 
 }  // namespace
 
-uint64_t HighwayTreeAVX2(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+uint64_t AVX2HighwayTree(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
                          const uint64_t size) {
   HighwayTreeHashState state(key);
 
@@ -183,17 +183,18 @@ uint64_t HighwayTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
   if (!highwayTreeFP) {
     __builtin_cpu_init();
-    printf("checking HighwayTreeHash implementation... ");
     if (__builtin_cpu_supports("avx2")) {
-      printf("AVX2\n");
-      highwayTreeFP = &HighwayTreeAVX2;
+      highwayTreeFP = &AVX2HighwayTree;
     } else {
-      printf("scalar\n");
       highwayTreeFP = &ScalarHighwayTreeHash;
     }
+#ifdef DEBUG
+    printf("checking HighwayTreeHash implementation... %s\n",
+      __builtin_cpu_supports("avx2")? "avx2": "scalar");
+#endif
   }
   return highwayTreeFP(key, bytes, size);
 #else
-  HighwayTreeAVX2(key, bytes, size);
+  AVX2HighwayTree(key, bytes, size);
 #endif
 }

--- a/highway_tree_hash.cc
+++ b/highway_tree_hash.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include "highway_tree_hash.h"
+#include "scalar_highway_tree_hash.h"
 
 #include <cstring>  // memcpy
 #include "vec2.h"
@@ -151,7 +153,7 @@ static INLINE V4x64U LoadFinalPacket32(const uint8_t* bytes,
 
 }  // namespace
 
-uint64_t HighwayTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+uint64_t HighwayTreeAVX2(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
                          const uint64_t size) {
   HighwayTreeHashState state(key);
 
@@ -168,4 +170,30 @@ uint64_t HighwayTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   state.Update(final_packet);
 
   return state.Finalize();
+}
+
+static uint64_t(*highwayTreeFP)(const uint64_t (&)[kNumLanes], const uint8_t*,
+                                const uint64_t);
+
+uint64_t HighwayTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+                         const uint64_t size) {
+
+// __builtin_cpu_supports is available in GCC 4.8 and higher
+#if __GNUC__ > 4 || \
+  (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
+  if (!highwayTreeFP) {
+    __builtin_cpu_init();
+    printf("checking HighwayTreeHash implementation... ");
+    if (__builtin_cpu_supports("avx2")) {
+      printf("AVX2\n");
+      highwayTreeFP = &HighwayTreeAVX2;
+    } else {
+      printf("scalar\n");
+      highwayTreeFP = &ScalarHighwayTreeHash;
+    }
+  }
+  return highwayTreeFP(key, bytes, size);
+#else
+  HighwayTreeAVX2(key, bytes, size);
+#endif
 }

--- a/scalar_highway_tree_hash.cc
+++ b/scalar_highway_tree_hash.cc
@@ -15,7 +15,7 @@
 #include "scalar_highway_tree_hash.h"
 
 #include <cstring>  // memcpy
-#include "vec2.h"
+#include "code_annotation.h"
 
 namespace {
 

--- a/scalar_sip_tree_hash.cc
+++ b/scalar_sip_tree_hash.cc
@@ -16,7 +16,7 @@
 #include "sip_hash.h"
 
 #include <cstring>  // memcpy
-#include "vec2.h"
+#include "code_annotation.h"
 
 namespace {
 

--- a/sip_hash.cc
+++ b/sip_hash.cc
@@ -164,14 +164,15 @@ uint64_t SipHash(const uint64_t key[2], const uint8_t* bytes,
   (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
   if (!siphashFP) {
     __builtin_cpu_init();
-    printf("checking SipHash implementation... ");
     if (__builtin_cpu_supports("avx2")) {
-      printf("AVX2\n");
       siphashFP = &AVX2SipHash;
     } else {
-      printf("sse4.1\n");
       siphashFP = &SSE41SipHash;
     }
+#ifdef DEBUG
+    printf("checking SipHash implementation... %s\n",
+      __builtin_cpu_supports("avx2")? "avx2": "sse4.1");
+#endif
   }
   return siphashFP(key, bytes, size);
 #else
@@ -185,14 +186,15 @@ uint64_t ReduceSipTreeHash(const uint64_t key[2], const uint64_t hashes[4]) {
   (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
   if (!reducesiptreehashFP) {
     __builtin_cpu_init();
-    printf("checking ReduceSipTreeHash implementation... ");
     if (__builtin_cpu_supports("avx2")) {
-      printf("AVX2\n");
       reducesiptreehashFP = &AVX2ReduceSipTreeHash;
     } else {
-      printf("sse4.1\n");
       reducesiptreehashFP = &SSE41ReduceSipTreeHash;
     }
+#ifdef DEBUG
+    printf("checking ReduceSipTreeHash implementation... %s\n",
+      __builtin_cpu_supports("avx2")? "avx2": "sse4.1");
+#endif
   }
   return reducesiptreehashFP(key, hashes);
 #else

--- a/sip_hash_main.cc
+++ b/sip_hash_main.cc
@@ -30,6 +30,7 @@
 #include "scalar_highway_tree_hash.h"
 #include "scalar_sip_tree_hash.h"
 #include "sip_hash.h"
+#include "sse41_sip_hash.h"
 #include "sip_tree_hash.h"
 #include "code_annotation.h"
 //#include "vec2.h"
@@ -206,14 +207,16 @@ static void Benchmark(const char* caption, const Function& hash_function) {
 }
 
 int main(int argc, char* argv[]) {
-  // Benchmark("ScalarSipTreeHash", ScalarSipTreeHash);
+  Benchmark("ScalarSipTreeHash", ScalarSipTreeHash);
   Benchmark("ScalarHighwayTreeHash", ScalarHighwayTreeHash);
-  //Benchmark("SipHash", SipHash);
-  //Benchmark("SipTreeHash", SipTreeHash);
+  Benchmark("SipHash", SipHash);
+  Benchmark("SSE41SipHash", SSE41SipHash);
+  Benchmark("SipTreeHash", SipTreeHash);
   Benchmark("HighwayTreeHash", HighwayTreeHash);
 
-  //VerifySipHash();
-  //VerifyEqual("SipTree scalar", SipTreeHash, ScalarSipTreeHash);
+  VerifySipHash();
+  VerifyEqual("SipHash SSE41", SipHash, SSE41SipHash);
+  VerifyEqual("SipTree scalar", SipTreeHash, ScalarSipTreeHash);
   VerifyEqual("HighwayTree scalar", HighwayTreeHash, ScalarHighwayTreeHash);
 
   return 0;

--- a/sip_hash_main.cc
+++ b/sip_hash_main.cc
@@ -31,7 +31,8 @@
 #include "scalar_sip_tree_hash.h"
 #include "sip_hash.h"
 #include "sip_tree_hash.h"
-#include "vec2.h"
+#include "code_annotation.h"
+//#include "vec2.h"
 
 uint64_t TimerTicks() {
 #ifdef _WIN32
@@ -205,14 +206,14 @@ static void Benchmark(const char* caption, const Function& hash_function) {
 }
 
 int main(int argc, char* argv[]) {
-  Benchmark("ScalarSipTreeHash", ScalarSipTreeHash);
+  // Benchmark("ScalarSipTreeHash", ScalarSipTreeHash);
   Benchmark("ScalarHighwayTreeHash", ScalarHighwayTreeHash);
-  Benchmark("SipHash", SipHash);
-  Benchmark("SipTreeHash", SipTreeHash);
+  //Benchmark("SipHash", SipHash);
+  //Benchmark("SipTreeHash", SipTreeHash);
   Benchmark("HighwayTreeHash", HighwayTreeHash);
 
-  VerifySipHash();
-  VerifyEqual("SipTree scalar", SipTreeHash, ScalarSipTreeHash);
+  //VerifySipHash();
+  //VerifyEqual("SipTree scalar", SipTreeHash, ScalarSipTreeHash);
   VerifyEqual("HighwayTree scalar", HighwayTreeHash, ScalarHighwayTreeHash);
 
   return 0;

--- a/sip_tree_hash.cc
+++ b/sip_tree_hash.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include "sip_tree_hash.h"
+#include "scalar_sip_tree_hash.h"
 
 #include <cstring>  // memcpy
 #include "sip_hash.h"
@@ -157,7 +159,7 @@ static INLINE V4x64U LoadFinalPacket32(const uint8_t* bytes,
 
 }  // namespace
 
-uint64_t SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+uint64_t SipTreeHashAVX2(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
                      const uint64_t size) {
   SipTreeHashState state(key);
 
@@ -179,4 +181,29 @@ uint64_t SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   Store(state.Finalize(), hashes);
 
   return ReduceSipTreeHash(key, hashes);
+}
+
+static uint64_t (*SipTreeFP)(const uint64_t (&)[kNumLanes], const uint8_t*,
+                             const uint64_t);
+
+uint64_t SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+                     const uint64_t size) {
+// __builtin_cpu_supports is available in GCC 4.8 and higher
+#if __GNUC__ > 4 || \
+  (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
+  if (!SipTreeFP) {
+    __builtin_cpu_init();
+    printf("checking SipTreeHash implementation... ");
+    if (__builtin_cpu_supports("avx2")) {
+      printf("AVX2\n");
+      SipTreeFP = &SipTreeHashAVX2;
+    } else {
+      printf("scalar\n");
+      SipTreeFP = &ScalarSipTreeHash;
+    }
+  }
+  return SipTreeFP(key, bytes, size);
+#else
+  SipTreeHashAVX2(key, bytes, size);
+#endif
 }

--- a/sip_tree_hash.cc
+++ b/sip_tree_hash.cc
@@ -159,7 +159,7 @@ static INLINE V4x64U LoadFinalPacket32(const uint8_t* bytes,
 
 }  // namespace
 
-uint64_t SipTreeHashAVX2(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
+uint64_t AVX2SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
                      const uint64_t size) {
   SipTreeHashState state(key);
 
@@ -193,17 +193,18 @@ uint64_t SipTreeHash(const uint64_t (&key)[kNumLanes], const uint8_t* bytes,
   (__GNUC__ == 4 && (__GNUC_MINOR__ > 8 || __GNUC_MINOR__ == 8))
   if (!SipTreeFP) {
     __builtin_cpu_init();
-    printf("checking SipTreeHash implementation... ");
     if (__builtin_cpu_supports("avx2")) {
-      printf("AVX2\n");
-      SipTreeFP = &SipTreeHashAVX2;
+      SipTreeFP = &AVX2SipTreeHash;
     } else {
-      printf("scalar\n");
       SipTreeFP = &ScalarSipTreeHash;
     }
+#ifdef DEBUG
+    printf("checking SipTreeHash implementation... %s\n",
+      __builtin_cpu_supports("avx2")? "avx2": "scalar");
+#endif
   }
   return SipTreeFP(key, bytes, size);
 #else
-  SipTreeHashAVX2(key, bytes, size);
+  AVX2SipTreeHash(key, bytes, size);
 #endif
 }

--- a/sse41_sip_hash.h
+++ b/sse41_sip_hash.h
@@ -1,0 +1,48 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HIGHWAYHASH_SSE41_SIP_HASH_H_
+#define HIGHWAYHASH_SSE41_SIP_HASH_H_
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Fast, cryptographically strong pseudo-random function. Useful for:
+// . hash tables holding attacker-controlled data. This function is
+//   immune to hash flooding DOS attacks because multi-collisions are
+//   infeasible to compute, provided the key remains secret.
+// . deterministic/idempotent 'random' number generation, e.g. for
+//   choosing a subset of items based on their contents.
+//
+// Robust versus timing attacks because memory accesses are sequential
+// and the algorithm is branch-free. This implementation only uses sse41
+// instructions.
+//
+// "key" is a secret 128-bit key unknown to attackers.
+// "bytes" is the data to hash; ceil(size / 8) * 8 bytes are read.
+// Returns a 64-bit hash of the given data bytes.
+uint64_t SSE41SipHash(const uint64_t key[2], const uint8_t* bytes,
+                 const uint64_t size);
+
+uint64_t SSE41ReduceSipTreeHash(const uint64_t key[2], const uint64_t hashes[4]);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // #ifndef HIGHWAYHASH_SSE41_SIP_HASH_H_
+

--- a/vec.h
+++ b/vec.h
@@ -103,6 +103,14 @@ class V2x64U {
     return *this;
   }
 
+  INLINE uint64_t extract64(const int index) {
+    return _mm_extract_epi64(v_, index);
+  }
+
+  INLINE uint32_t extract32(const int index) {
+    return _mm_extract_epi32(v_, index);
+  }
+
  private:
   __m128i v_;
 };


### PR DESCRIPTION
This patch support the following:
* Use ` __builtin_cpu_supports("avx2")` at runtime to determine if the host/target machine supports avx2
* If avx2 is supported, use the best implementation.
* If not supported, fallback to scalar/sse4.1 implementation.
* The test would be cached in a static function pointer.

It has been tested on my old machine that only have sse4.1 but without avx2.

The Makefile optimization flag changed from O3 to O2. Using O3 with `-mavx2` would make gcc try to use avx2 instruction on scalar programs as well. As the goal is to have the binary able to run on older machine, I turned it off. Fortunately it didn't affect the performance that much. Most of the time it is optimizing variable init only.

The sip_hash implementation uses avx2, and it is also used by scalar_sip_tree_hash. To make it portable to older machine, I created sse41_sip_hash.cc.

This implementation requires gcc-4.8 or above. (newer clang seems to have a patch to support this, but I haven't test it). I wrote the macro that if CXX on build machine is gcc-4.8 or above, enable the runtime lookup, else just behave as is.