### PR TITLE
Don't pollute global namespace with #defines

### DIFF
--- a/highwayhash/code_annotation.h
+++ b/highwayhash/code_annotation.h
@@ -52,68 +52,68 @@
 // Marks a function parameter as unused and avoids
 // the corresponding compiler warning.
 // Wrap around the parameter name, e.g. void f(int UNUSED(x))
-#define UNUSED(param)
+#define HIGHWAYHASH_UNUSED(param)
 
 // Marks a function local variable or parameter as unused and avoids
 // the corresponding compiler warning.
 // Use instead of UNUSED when the parameter is conditionally unused.
-#define UNUSED2(param) ((void)(param))
+#define HIGHWAYHASH_UNUSED2(param) ((void)(param))
 
-#define NONCOPYABLE(className)          \
+#define HIGHWAYHASH_NONCOPYABLE(className)          \
   className(const className&) = delete; \
   const className& operator=(const className&) = delete;
 
 #if MSC_VERSION
-#define RESTRICT __restrict
+#define HIGHWAYHASH_RESTRICT __restrict
 #elif GCC_VERSION
-#define RESTRICT __restrict__
+#define HIGHWAYHASH_RESTRICT __restrict__
 #else
-#define RESTRICT
+#define HIGHWAYHASH_RESTRICT
 #endif
 
 #if MSC_VERSION
-#define INLINE __forceinline
+#define HIGHWAYHASH_INLINE __forceinline
 #else
-#define INLINE inline
+#define HIGHWAYHASH_INLINE inline
 #endif
 
 #if MSC_VERSION
-#define NORETURN __declspec(noreturn)
+#define HIGHWAYHASH_NORETURN __declspec(noreturn)
 #elif GCC_VERSION
-#define NORETURN __attribute__((noreturn))
+#define HIGHWAYHASH_NORETURN __attribute__((noreturn))
 #endif
 
 #if MSC_VERSION
 #include <intrin.h>
 #pragma intrinsic(_ReadWriteBarrier)
-#define COMPILER_FENCE _ReadWriteBarrier()
+#define HIGHWAYHASH_COMPILER_FENCE _ReadWriteBarrier()
 #elif GCC_VERSION
-#define COMPILER_FENCE asm volatile("" : : : "memory")
+#define HIGHWAYHASH_COMPILER_FENCE asm volatile("" : : : "memory")
 #else
-#define COMPILER_FENCE
+#define HIGHWAYHASH_COMPILER_FENCE
 #endif
 
 // Informs the compiler that the preceding function returns a pointer with the
 // specified alignment. This may improve code generation.
 #if MSC_VERSION
-#define CACHE_ALIGNED_RETURN /* not supported */
+#define HIGHWAYHASH_CACHE_ALIGNED_RETURN /* not supported */
 #else
-#define CACHE_ALIGNED_RETURN __attribute__((assume_aligned(64)))
+#define HIGHWAYHASH_CACHE_ALIGNED_RETURN __attribute__((assume_aligned(64)))
 #endif
 
 #if MSC_VERSION
-#define DEBUG_BREAK __debugbreak()
+#define HIGHWAYHASH_DEBUG_BREAK __debugbreak()
 #elif CLANG_VERSION
-#define DEBUG_BREAK __builtin_debugger()
+#define HIGHWAYHASH_DEBUG_BREAK __builtin_debugger()
 #elif GCC_VERSION
-#define DEBUG_BREAK __builtin_trap()
+#define HIGHWAYHASH_DEBUG_BREAK __builtin_trap()
 #endif
 
 #if MSC_VERSION
 #include <sal.h>
-#define FORMAT_STRING(s) _Printf_format_string_ s
+#define HIGHWAYHASH_FORMAT_STRING(s) _Printf_format_string_ s
 #else
-#define FORMAT_STRING(s) s
+#define HIGHWAYHASH_FORMAT_STRING(s) s
 #endif
 
 // Function taking a reference to an array and returning a pointer to
@@ -124,16 +124,16 @@ char (*ArraySizeDeducer(T (&)[n]))[n];
 
 // Number of elements in an array. Safer than sizeof(name) / sizeof(name[0])
 // because it doesn't compile when a pointer is passed.
-#define ARRAY_SIZE(name) (sizeof(*ArraySizeDeducer(name)))
+#define HIGHWAYHASH_ARRAY_SIZE(name) (sizeof(*ArraySizeDeducer(name)))
 
 // decltype(T)::x cannot be used directly when T is a reference type, so
 // we need to remove the reference first.
-#define TYPE(T) std::remove_reference<decltype(T)>::type
+#define HIGHWAYHASH_TYPE(T) std::remove_reference<decltype(T)>::type
 
-#define CONCAT2(a, b) a##b
-#define CONCAT(a, b) CONCAT2(a, b)
+#define HIGHWAYHASH_CONCAT2(a, b) a##b
+#define HIGHWAYHASH_CONCAT(a, b) CONCAT2(a, b)
 
 // Generates a unique lvalue name.
-#define UNIQUE(prefix) CONCAT(prefix, __LINE__)
+#define HIGHWAYHASH_UNIQUE(prefix) CONCAT(prefix, __LINE__)
 
 #endif  // #ifndef HIGHWAYHASH_HIGHWAYHASH_CODE_ANNOTATION_H_

--- a/highwayhash/profiler.h
+++ b/highwayhash/profiler.h
@@ -75,7 +75,7 @@ class CacheAligned {
   static constexpr size_t kPointerSize = sizeof(void*);
   static constexpr size_t kCacheLineSize = 64;
 
-  static void* Allocate(const size_t bytes) CACHE_ALIGNED_RETURN {
+  static void* Allocate(const size_t bytes) HIGHWAYHASH_CACHE_ALIGNED_RETURN {
     char* const allocated = static_cast<char*>(malloc(bytes + kCacheLineSize));
     if (allocated == nullptr) {
       return nullptr;
@@ -109,23 +109,23 @@ class CacheAligned {
     static_assert(sizeof(__m128i) % sizeof(T) == 0, "Cannot divide");
     const size_t kLanes = sizeof(__m128i) / sizeof(T);
     const __m128i v0 = LoadVector(from + 0 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     const __m128i v1 = LoadVector(from + 1 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     const __m128i v2 = LoadVector(from + 2 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     const __m128i v3 = LoadVector(from + 3 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     // Fences prevent the compiler from reordering loads/stores, which may
     // interfere with write-combining.
     StreamVector(v0, to + 0 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     StreamVector(v1, to + 1 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     StreamVector(v2, to + 2 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
     StreamVector(v3, to + 3 * kLanes);
-    COMPILER_FENCE;
+    HIGHWAYHASH_COMPILER_FENCE;
   }
 
  private:
@@ -305,7 +305,7 @@ class Results {
     const __m128i duration_64 = _mm_cvtsi64_si128(duration);
     const __m128i add_duration_call = _mm_unpacklo_epi64(one_64, duration_64);
 
-    __m128i* const RESTRICT zones = reinterpret_cast<__m128i*>(zones_);
+    __m128i* const HIGHWAYHASH_RESTRICT zones = reinterpret_cast<__m128i*>(zones_);
 
     // Special case for first zone: (maybe) update, without swapping.
     __m128i prev = _mm_load_si128(zones);

--- a/highwayhash/scalar_highway_tree_hash.h
+++ b/highwayhash/scalar_highway_tree_hash.h
@@ -32,7 +32,7 @@ class ScalarHighwayTreeHashState {
   using Key = Lanes;
   static const int kPacketSize = sizeof(Lanes);
 
-  INLINE ScalarHighwayTreeHashState(const Key& keys) {
+  HIGHWAYHASH_INLINE ScalarHighwayTreeHashState(const Key& keys) {
     static const Lanes init0 = {0xdbe6d5d5fe4cce2full, 0xa4093822299f31d0ull,
                                 0x13198a2e03707344ull, 0x243f6a8885a308d3ull};
     static const Lanes init1 = {0x3bd39e10cb0ef593ull, 0xc0acf169b5f18a8cull,
@@ -45,7 +45,7 @@ class ScalarHighwayTreeHashState {
     Xor(init1, permuted_keys, &v1);
   }
 
-  INLINE void Update(const char* bytes) {
+  HIGHWAYHASH_INLINE void Update(const char* bytes) {
     const Lanes& packets = *reinterpret_cast<const Lanes*>(bytes);
 
     Add(packets, &v1);
@@ -67,7 +67,7 @@ class ScalarHighwayTreeHashState {
     ZipperMergeAndAdd(v0[2], v0[3], &v1[2], &v1[3]);
   }
 
-  INLINE uint64 Finalize() {
+  HIGHWAYHASH_INLINE uint64 Finalize() {
     PermuteAndUpdate();
     PermuteAndUpdate();
     PermuteAndUpdate();
@@ -77,19 +77,19 @@ class ScalarHighwayTreeHashState {
   }
 
   // private:
-  static INLINE void Copy(const Lanes& source, Lanes* dest) {
+  static HIGHWAYHASH_INLINE void Copy(const Lanes& source, Lanes* dest) {
     for (int lane = 0; lane < kNumLanes; ++lane) {
       (*dest)[lane] = source[lane];
     }
   }
 
-  static INLINE void Add(const Lanes& source, Lanes* dest) {
+  static HIGHWAYHASH_INLINE void Add(const Lanes& source, Lanes* dest) {
     for (int lane = 0; lane < kNumLanes; ++lane) {
       (*dest)[lane] += source[lane];
     }
   }
 
-  static INLINE void Xor(const Lanes& op1, const Lanes& op2, Lanes* dest) {
+  static HIGHWAYHASH_INLINE void Xor(const Lanes& op1, const Lanes& op2, Lanes* dest) {
     for (int lane = 0; lane < kNumLanes; ++lane) {
       (*dest)[lane] = op1[lane] ^ op2[lane];
     }
@@ -100,9 +100,10 @@ class ScalarHighwayTreeHashState {
 
   // 16-byte permutation; shifting is about 10% faster than byte loads.
   // Adds zipper-merge result to add*.
-  static INLINE void ZipperMergeAndAdd(const uint64 v0, const uint64 v1,
-                                       uint64* RESTRICT add0,
-                                       uint64* RESTRICT add1) {
+  static HIGHWAYHASH_INLINE
+  void ZipperMergeAndAdd(const uint64 v0, const uint64 v1,
+                         uint64* HIGHWAYHASH_RESTRICT add0,
+                         uint64* HIGHWAYHASH_RESTRICT add1) {
     *add0 += ((MASK(v0, 3) + MASK(v1, 4)) >> 24) +
              ((MASK(v0, 5) + MASK(v1, 6)) >> 16) + MASK(v0, 2) +
              (MASK(v0, 1) << 32) + (MASK(v1, 7) >> 8) + (v0 << 56);
@@ -114,16 +115,16 @@ class ScalarHighwayTreeHashState {
 
 #undef MASK
 
-  static INLINE uint64 Rot32(const uint64 x) { return (x >> 32) | (x << 32); }
+  static HIGHWAYHASH_INLINE uint64 Rot32(const uint64 x) { return (x >> 32) | (x << 32); }
 
-  static INLINE void Permute(const Lanes& v, Lanes* permuted) {
+  static HIGHWAYHASH_INLINE void Permute(const Lanes& v, Lanes* permuted) {
     (*permuted)[0] = Rot32(v[2]);
     (*permuted)[1] = Rot32(v[3]);
     (*permuted)[2] = Rot32(v[0]);
     (*permuted)[3] = Rot32(v[1]);
   }
 
-  INLINE void PermuteAndUpdate() {
+  HIGHWAYHASH_INLINE void PermuteAndUpdate() {
     Lanes permuted;
     Permute(v0, &permuted);
     Update(reinterpret_cast<const char*>(permuted));
@@ -148,9 +149,10 @@ class ScalarHighwayTreeHashState {
 // HighwayTreeHash would return (drop-in compatible).
 //
 // Throughput: 1.1 GB/s for 1 KB inputs (about 10% of the AVX-2 version).
-static INLINE uint64 ScalarHighwayTreeHash(const uint64 (&key)[4],
-                                           const char* bytes,
-                                           const uint64 size) {
+static HIGHWAYHASH_INLINE
+uint64 ScalarHighwayTreeHash(const uint64 (&key)[4],
+                             const char* bytes,
+                             const uint64 size) {
   return ComputeHash<ScalarHighwayTreeHashState>(key, bytes, size);
 }
 

--- a/highwayhash/scalar_sip_tree_hash.cc
+++ b/highwayhash/scalar_sip_tree_hash.cc
@@ -38,7 +38,7 @@ const int kPacketSize = sizeof(Lanes);
 
 class ScalarSipTreeHashState {
  public:
-  INLINE ScalarSipTreeHashState(const Lanes& keys, const int lane) {
+  HIGHWAYHASH_INLINE ScalarSipTreeHashState(const Lanes& keys, const int lane) {
     const uint64 key = keys[lane] ^ (kNumLanes | lane);
     v0 = 0x736f6d6570736575ull ^ key;
     v1 = 0x646f72616e646f6dull ^ key;
@@ -46,7 +46,7 @@ class ScalarSipTreeHashState {
     v3 = 0x7465646279746573ull ^ key;
   }
 
-  INLINE void Update(const uint64& packet) {
+  HIGHWAYHASH_INLINE void Update(const uint64& packet) {
     v3 ^= packet;
 
     Compress<2>();
@@ -54,7 +54,7 @@ class ScalarSipTreeHashState {
     v0 ^= packet;
   }
 
-  INLINE uint64 Finalize() {
+  HIGHWAYHASH_INLINE uint64 Finalize() {
     // Mix in bits to avoid leaking the key if all packets were zero.
     v2 ^= 0xFF;
 
@@ -66,14 +66,14 @@ class ScalarSipTreeHashState {
  private:
   // Rotate a 64-bit value "v" left by N bits.
   template <uint64 bits>
-  static INLINE uint64 RotateLeft(const uint64 v) {
+  static HIGHWAYHASH_INLINE uint64 RotateLeft(const uint64 v) {
     const uint64 left = v << bits;
     const uint64 right = v >> (64 - bits);
     return left | right;
   }
 
   template <size_t rounds>
-  INLINE void Compress() {
+  HIGHWAYHASH_INLINE void Compress() {
     for (size_t i = 0; i < rounds; ++i) {
       // ARX network: add, rotate, exclusive-or.
       v0 += v1;

--- a/highwayhash/sip_hash.h
+++ b/highwayhash/sip_hash.h
@@ -32,14 +32,14 @@ class SipHashState {
   using Key = uint64[2];
   static const size_t kPacketSize = sizeof(uint64);
 
-  explicit INLINE SipHashState(const Key& key) {
+  explicit HIGHWAYHASH_INLINE SipHashState(const Key& key) {
     v0 = 0x736f6d6570736575ull ^ key[0];
     v1 = 0x646f72616e646f6dull ^ key[1];
     v2 = 0x6c7967656e657261ull ^ key[0];
     v3 = 0x7465646279746573ull ^ key[1];
   }
 
-  INLINE void Update(const char* bytes) {
+  HIGHWAYHASH_INLINE void Update(const char* bytes) {
     uint64 packet;
     memcpy(&packet, bytes, sizeof(packet));
 
@@ -50,7 +50,7 @@ class SipHashState {
     v0 ^= packet;
   }
 
-  INLINE uint64 Finalize() {
+  HIGHWAYHASH_INLINE uint64 Finalize() {
     // Mix in bits to avoid leaking the key if all packets were zero.
     v2 ^= 0xFF;
 
@@ -62,14 +62,14 @@ class SipHashState {
  private:
   // Rotate a 64-bit value "v" left by N bits.
   template <uint64 bits>
-  static INLINE uint64 RotateLeft(const uint64 v) {
+  static HIGHWAYHASH_INLINE uint64 RotateLeft(const uint64 v) {
     const uint64 left = v << bits;
     const uint64 right = v >> (64 - bits);
     return left | right;
   }
 
   template <size_t rounds>
-  INLINE void Compress() {
+  HIGHWAYHASH_INLINE void Compress() {
     for (size_t i = 0; i < rounds; ++i) {
       // ARX network: add, rotate, exclusive-or.
       v0 += v1;
@@ -101,10 +101,11 @@ class SipHashState {
 // Override the HighwayTreeHash padding scheme with that of SipHash so that
 // the hash output matches the known-good values in sip_hash_test.
 template <>
-INLINE void PaddedUpdate<SipHashState>(const uint64 size,
-                                       const char* remaining_bytes,
-                                       const uint64 remaining_size,
-                                       SipHashState* state) {
+HIGHWAYHASH_INLINE
+void PaddedUpdate<SipHashState>(const uint64 size,
+                                const char* remaining_bytes,
+                                const uint64 remaining_size,
+                                SipHashState* state) {
   // Copy to avoid overrunning the input buffer.
   char final_packet[SipHashState::kPacketSize] = {0};
   memcpy(final_packet, remaining_bytes, remaining_size);
@@ -126,14 +127,16 @@ INLINE void PaddedUpdate<SipHashState>(const uint64 size,
 // "key" is a secret 128-bit key unknown to attackers.
 // "bytes" is the data to hash; ceil(size / 8) * 8 bytes are read.
 // Returns a 64-bit hash of the given data bytes.
-static INLINE uint64 SipHash(const SipHashState::Key& key, const char* bytes,
-                             const uint64 size) {
+static HIGHWAYHASH_INLINE
+uint64 SipHash(const SipHashState::Key& key, const char* bytes,
+               const uint64 size) {
   return ComputeHash<SipHashState>(key, bytes, size);
 }
 
 template <int kNumLanes>
-static INLINE uint64 ReduceSipTreeHash(const SipHashState::Key& key,
-                                       const uint64 (&hashes)[kNumLanes]) {
+static HIGHWAYHASH_INLINE
+uint64 ReduceSipTreeHash(const SipHashState::Key& key,
+                         const uint64 (&hashes)[kNumLanes]) {
   SipHashState state(key);
 
   for (int i = 0; i < kNumLanes; ++i) {

--- a/highwayhash/sip_tree_hash.cc
+++ b/highwayhash/sip_tree_hash.cc
@@ -37,7 +37,7 @@ const int kNumLanes = kPacketSize / sizeof(uint64);
 // 32 bytes key. Parameters are hardwired to c=2, d=4 [rounds].
 class SipTreeHashState {
  public:
-  explicit INLINE SipTreeHashState(const uint64 (&keys)[kNumLanes]) {
+  explicit HIGHWAYHASH_INLINE SipTreeHashState(const uint64 (&keys)[kNumLanes]) {
     const V4x64U init(0x7465646279746573ull, 0x6c7967656e657261ull,
                       0x646f72616e646f6dull, 0x736f6d6570736575ull);
     const V4x64U lanes(kNumLanes | 3, kNumLanes | 2, kNumLanes | 1,
@@ -49,7 +49,7 @@ class SipTreeHashState {
     v3 = V4x64U(_mm256_permute4x64_epi64(init, 0xFF)) ^ key;
   }
 
-  INLINE void Update(const V4x64U& packet) {
+  HIGHWAYHASH_INLINE void Update(const V4x64U& packet) {
     v3 ^= packet;
 
     Compress<2>();
@@ -57,7 +57,7 @@ class SipTreeHashState {
     v0 ^= packet;
   }
 
-  INLINE V4x64U Finalize() {
+  HIGHWAYHASH_INLINE V4x64U Finalize() {
     // Mix in bits to avoid leaking the key if all packets were zero.
     v2 ^= V4x64U(0xFF);
 
@@ -67,7 +67,7 @@ class SipTreeHashState {
   }
 
  private:
-  static INLINE V4x64U RotateLeft16(const V4x64U& v) {
+  static HIGHWAYHASH_INLINE V4x64U RotateLeft16(const V4x64U& v) {
     const V4x64U control(0x0D0C0B0A09080F0EULL, 0x0504030201000706ULL,
                          0x0D0C0B0A09080F0EULL, 0x0504030201000706ULL);
     return V4x64U(_mm256_shuffle_epi8(v, control));
@@ -75,18 +75,18 @@ class SipTreeHashState {
 
   // Rotates each 64-bit element of "v" left by N bits.
   template <uint64 bits>
-  static INLINE V4x64U RotateLeft(const V4x64U& v) {
+  static HIGHWAYHASH_INLINE V4x64U RotateLeft(const V4x64U& v) {
     const V4x64U left = v << bits;
     const V4x64U right = v >> (64 - bits);
     return left | right;
   }
 
-  static INLINE V4x64U Rotate32(const V4x64U& v) {
+  static HIGHWAYHASH_INLINE V4x64U Rotate32(const V4x64U& v) {
     return V4x64U(_mm256_shuffle_epi32(v, _MM_SHUFFLE(2, 3, 0, 1)));
   }
 
   template <size_t rounds>
-  INLINE void Compress() {
+  HIGHWAYHASH_INLINE void Compress() {
     // Loop is faster than unrolling!
     for (size_t i = 0; i < rounds; ++i) {
       // ARX network: add, rotate, exclusive-or.
@@ -121,8 +121,9 @@ class SipTreeHashState {
 // "remainder" is the number of accessible/remaining bytes (size % 32).
 // Loading past the end of the input risks page fault exceptions which even
 // LDDQU cannot prevent.
-static INLINE V4x64U LoadFinalPacket32(const char* bytes, const uint64 size,
-                                       const uint64 remainder) {
+static HIGHWAYHASH_INLINE
+V4x64U LoadFinalPacket32(const char* bytes, const uint64 size,
+                         const uint64 remainder) {
   // Copying into an aligned buffer incurs a store-to-load-forwarding stall.
   // Instead, we use masked loads to read any remaining whole uint32
   // without incurring page faults for the others.

--- a/highwayhash/sse41_highway_tree_hash.h
+++ b/highwayhash/sse41_highway_tree_hash.h
@@ -34,7 +34,7 @@ class SSE41HighwayTreeHashState {
   using Key = uint64[4];
   static const int kPacketSize = sizeof(Key);
 
-  explicit INLINE SSE41HighwayTreeHashState(const Key& key) {
+  explicit HIGHWAYHASH_INLINE SSE41HighwayTreeHashState(const Key& key) {
     // "Nothing up my sleeve numbers"; see HighwayTreeHashState.
     const V2x64U init0L(0xa4093822299f31d0ull, 0xdbe6d5d5fe4cce2full);
     const V2x64U init0H(0x243f6a8885a308d3ull, 0x13198a2e03707344ull);
@@ -52,7 +52,7 @@ class SSE41HighwayTreeHashState {
     mul1H = init1H;
   }
 
-  INLINE void Update(const V2x64U& packetL, const V2x64U& packetH) {
+  HIGHWAYHASH_INLINE void Update(const V2x64U& packetL, const V2x64U& packetH) {
     v1L += packetL;
     v1H += packetH;
     v1L += mul0L;
@@ -69,14 +69,14 @@ class SSE41HighwayTreeHashState {
     v1H += ZipperMerge(v0H);
   }
 
-  INLINE void Update(const char* bytes) {
+  HIGHWAYHASH_INLINE void Update(const char* bytes) {
     const uint64* words = reinterpret_cast<const uint64*>(bytes);
     const V2x64U packetL = Load2U(words + 0);
     const V2x64U packetH = Load2U(words + 2);
     Update(packetL, packetH);
   }
 
-  INLINE uint64 Finalize() {
+  HIGHWAYHASH_INLINE uint64 Finalize() {
     // Mix together all lanes.
     PermuteAndUpdate();
     PermuteAndUpdate();
@@ -98,7 +98,7 @@ class SSE41HighwayTreeHashState {
            lanesL[0]);
   }
 
-  static INLINE V2x64U ZipperMerge(const V2x64U& v) {
+  static HIGHWAYHASH_INLINE V2x64U ZipperMerge(const V2x64U& v) {
     // Multiplication mixes/scrambles bytes 0-7 of the 64-bit result to
     // varying degrees. In descending order of goodness, bytes
     // 3 4 2 5 1 6 0 7 have quality 228 224 164 160 100 96 36 32.
@@ -114,11 +114,11 @@ class SSE41HighwayTreeHashState {
   }
 
   // Swap 32-bit halves of each lane (caller swaps 128-bit halves)
-  static INLINE V2x64U Rot32(const V2x64U& v) {
+  static HIGHWAYHASH_INLINE V2x64U Rot32(const V2x64U& v) {
     return V2x64U(_mm_shuffle_epi32(v, _MM_SHUFFLE(2, 3, 0, 1)));
   }
 
-  INLINE void PermuteAndUpdate() {
+  HIGHWAYHASH_INLINE void PermuteAndUpdate() {
     // It is slightly better to permute v0 than v1; it will be added to v1.
     // AVX-2 Permute also swaps 128-bit halves, so swap input operands.
     Update(Rot32(v0H), Rot32(v0L));
@@ -147,9 +147,10 @@ class SSE41HighwayTreeHashState {
 // HighwayTreeHash would return (drop-in compatible).
 //
 // Throughput: 8.2 GB/s for 1 KB inputs (about 75% of the AVX-2 version).
-static INLINE uint64 SSE41HighwayTreeHash(const uint64 (&key)[4],
-                                          const char* bytes,
-                                          const uint64 size) {
+static HIGHWAYHASH_INLINE
+uint64 SSE41HighwayTreeHash(const uint64 (&key)[4],
+                            const char* bytes,
+                            const uint64 size) {
   return ComputeHash<SSE41HighwayTreeHashState>(key, bytes, size);
 }
 

--- a/highwayhash/state_helpers.h
+++ b/highwayhash/state_helpers.h
@@ -26,8 +26,9 @@ namespace highwayhash {
 // Primary template; the specialization for AVX-2 is faster. Intended as an
 // implementation detail, do not call directly.
 template <class State>
-INLINE void PaddedUpdate(const uint64 size, const char* remaining_bytes,
-                         const uint64 remaining_size, State* state) {
+HIGHWAYHASH_INLINE
+void PaddedUpdate(const uint64 size, const char* remaining_bytes,
+                  const uint64 remaining_size, State* state) {
   alignas(32) char final_packet[State::kPacketSize] = {0};
 
   // Unusual layout matches the AVX-2 specialization in highway_tree_hash.h.
@@ -48,7 +49,8 @@ INLINE void PaddedUpdate(const uint64 size, const char* remaining_bytes,
 // Updates hash state for every whole packet, and once more for the final
 // padded packet.
 template <class State>
-INLINE void UpdateState(const char* bytes, const uint64 size, State* state) {
+HIGHWAYHASH_INLINE
+void UpdateState(const char* bytes, const uint64 size, State* state) {
   // Feed entire packets.
   const int kPacketSize = State::kPacketSize;
   static_assert((kPacketSize & (kPacketSize - 1)) == 0, "Size must be 2^i.");
@@ -63,7 +65,7 @@ INLINE void UpdateState(const char* bytes, const uint64 size, State* state) {
 
 // Convenience function for updating with the bytes of a string.
 template <class String, class State>
-INLINE void UpdateState(const String& s, State* state) {
+HIGHWAYHASH_INLINE void UpdateState(const String& s, State* state) {
   const char* bytes = reinterpret_cast<const char*>(s.data());
   const size_t size = s.length() * sizeof(typename String::value_type);
   UpdateState(bytes, size, state);

--- a/highwayhash/tsc_timer.h
+++ b/highwayhash/tsc_timer.h
@@ -186,7 +186,7 @@ inline uint64_t Stop<uint64_t>() {
 }
 
 template <typename T>
-using crpc = const T* const RESTRICT;
+using crpc = const T* const HIGHWAYHASH_RESTRICT;
 
 // Even with high-priority pinned threads and frequency throttling disabled,
 // elapsed times are noisy due to interrupts or SMM operations. It might help
@@ -260,7 +260,7 @@ void CountingSort(T* begin, T* end) {
   std::sort(unique.begin(), unique.end());
 
   // Write that many copies of each unique value to the array.
-  T* RESTRICT p = begin;
+  T* HIGHWAYHASH_RESTRICT p = begin;
   for (const auto& value_count : unique) {
     std::fill(p, p + value_count.second, value_count.first);
     p += value_count.second;

--- a/highwayhash/types.h
+++ b/highwayhash/types.h
@@ -16,14 +16,14 @@ typedef unsigned int uint32;
 typedef unsigned char uint8;
 
 // Pointer to const
-typedef const uint8* const RESTRICT crpcU8;
-typedef const uint32* const RESTRICT crpcU32;
-typedef const uint64* const RESTRICT crpcU64;
+typedef const uint8* const HIGHWAYHASH_RESTRICT crpcU8;
+typedef const uint32* const HIGHWAYHASH_RESTRICT crpcU32;
+typedef const uint64* const HIGHWAYHASH_RESTRICT crpcU64;
 
 // Pointer to non-const
-typedef uint8* const RESTRICT crpU8;
-typedef uint32* const RESTRICT crpU32;
-typedef uint64* const RESTRICT crpU64;
+typedef uint8* const HIGHWAYHASH_RESTRICT crpU8;
+typedef uint32* const HIGHWAYHASH_RESTRICT crpU32;
+typedef uint64* const HIGHWAYHASH_RESTRICT crpU64;
 
 #ifdef __cplusplus
 }  // namespace highwayhash

--- a/highwayhash/vec.h
+++ b/highwayhash/vec.h
@@ -41,67 +41,67 @@ class V2x64U {
   static constexpr size_t kNumLanes = sizeof(__m128i) / sizeof(T);
 
   // Leaves v_ uninitialized - typically used for output parameters.
-  INLINE V2x64U() {}
+  HIGHWAYHASH_INLINE V2x64U() {}
 
   // Lane 0 (p_0) is the lowest.
-  INLINE V2x64U(T p_1, T p_0) : v_(_mm_set_epi64x(p_1, p_0)) {}
+  HIGHWAYHASH_INLINE V2x64U(T p_1, T p_0) : v_(_mm_set_epi64x(p_1, p_0)) {}
   //
 
   // Broadcasts i to all lanes (usually by loading from memory).
-  INLINE explicit V2x64U(T i) : v_(_mm_set_epi64x(i, i)) {}
+  HIGHWAYHASH_INLINE explicit V2x64U(T i) : v_(_mm_set_epi64x(i, i)) {}
   //
 
   // Converts to/from intrinsics.
-  INLINE explicit V2x64U(const __m128i& v) : v_(v) {}
-  INLINE operator __m128i() const { return v_; }
-  INLINE V2x64U& operator=(const __m128i& v) {
+  HIGHWAYHASH_INLINE explicit V2x64U(const __m128i& v) : v_(v) {}
+  HIGHWAYHASH_INLINE operator __m128i() const { return v_; }
+  HIGHWAYHASH_INLINE V2x64U& operator=(const __m128i& v) {
     v_ = v;
     return *this;
   }
 
   // _mm_setzero_epi64 generates suboptimal code. Instead set
   // z = x - x (given an existing "x"), or x == x to set all bits.
-  INLINE V2x64U& operator=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator=(const V2x64U& other) {
     v_ = other.v_;
     return *this;
   }
 
-  INLINE V2x64U& operator+=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator+=(const V2x64U& other) {
     v_ = _mm_add_epi64(v_, other);
     return *this;
   }
-  INLINE V2x64U& operator-=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator-=(const V2x64U& other) {
     v_ = _mm_sub_epi64(v_, other);
     return *this;
   }
 
-  INLINE V2x64U& operator&=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator&=(const V2x64U& other) {
     v_ = _mm_and_si128(v_, other);
     return *this;
   }
-  INLINE V2x64U& operator|=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator|=(const V2x64U& other) {
     v_ = _mm_or_si128(v_, other);
     return *this;
   }
-  INLINE V2x64U& operator^=(const V2x64U& other) {
+  HIGHWAYHASH_INLINE V2x64U& operator^=(const V2x64U& other) {
     v_ = _mm_xor_si128(v_, other);
     return *this;
   }
 
-  INLINE V2x64U& operator<<=(const int count) {
+  HIGHWAYHASH_INLINE V2x64U& operator<<=(const int count) {
     v_ = _mm_slli_epi64(v_, count);
     return *this;
   }
-  INLINE V2x64U& operator<<=(const __m128i& count) {
+  HIGHWAYHASH_INLINE V2x64U& operator<<=(const __m128i& count) {
     v_ = _mm_sll_epi64(v_, count);
     return *this;
   }
 
-  INLINE V2x64U& operator>>=(const int count) {
+  HIGHWAYHASH_INLINE V2x64U& operator>>=(const int count) {
     v_ = _mm_srli_epi64(v_, count);
     return *this;
   }
-  INLINE V2x64U& operator>>=(const __m128i& count) {
+  HIGHWAYHASH_INLINE V2x64U& operator>>=(const __m128i& count) {
     v_ = _mm_srl_epi64(v_, count);
     return *this;
   }
@@ -112,47 +112,56 @@ class V2x64U {
 
 // Nonmember functions implemented in terms of member functions
 
-static INLINE V2x64U operator+(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator+(const V2x64U& left, const V2x64U& right) {
   V2x64U t(left);
   return t += right;
 }
 
-static INLINE V2x64U operator-(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator-(const V2x64U& left, const V2x64U& right) {
   V2x64U t(left);
   return t -= right;
 }
 
-static INLINE V2x64U operator<<(const V2x64U& v, const int count) {
+static HIGHWAYHASH_INLINE
+V2x64U operator<<(const V2x64U& v, const int count) {
   V2x64U t(v);
   return t <<= count;
 }
 
-static INLINE V2x64U operator>>(const V2x64U& v, const int count) {
+static HIGHWAYHASH_INLINE
+V2x64U operator>>(const V2x64U& v, const int count) {
   V2x64U t(v);
   return t >>= count;
 }
 
-static INLINE V2x64U operator<<(const V2x64U& v, const __m128i& count) {
+static HIGHWAYHASH_INLINE
+V2x64U operator<<(const V2x64U& v, const __m128i& count) {
   V2x64U t(v);
   return t <<= count;
 }
 
-static INLINE V2x64U operator>>(const V2x64U& v, const __m128i& count) {
+static HIGHWAYHASH_INLINE
+V2x64U operator>>(const V2x64U& v, const __m128i& count) {
   V2x64U t(v);
   return t >>= count;
 }
 
-static INLINE V2x64U operator&(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator&(const V2x64U& left, const V2x64U& right) {
   V2x64U t(left);
   return t &= right;
 }
 
-static INLINE V2x64U operator|(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator|(const V2x64U& left, const V2x64U& right) {
   V2x64U t(left);
   return t |= right;
 }
 
-static INLINE V2x64U operator^(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator^(const V2x64U& left, const V2x64U& right) {
   V2x64U t(left);
   return t ^= right;
 }
@@ -160,48 +169,58 @@ static INLINE V2x64U operator^(const V2x64U& left, const V2x64U& right) {
 // Load/Store.
 
 // "from" must be vector-aligned.
-static INLINE V2x64U Load2(const uint64* RESTRICT const from) {
+static HIGHWAYHASH_INLINE
+V2x64U Load2(const uint64* HIGHWAYHASH_RESTRICT const from) {
   return V2x64U(_mm_load_si128(reinterpret_cast<const __m128i*>(from)));
 }
 
-static INLINE V2x64U Load2U(const uint64* RESTRICT const from) {
+static HIGHWAYHASH_INLINE
+V2x64U Load2U(const uint64* HIGHWAYHASH_RESTRICT const from) {
   return V2x64U(_mm_loadu_si128(reinterpret_cast<const __m128i*>(from)));
 }
 
 // "to" must be vector-aligned.
-static INLINE void Store(const V2x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void Store(const V2x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm_store_si128(reinterpret_cast<__m128i*>(to), v);
 }
 
-static INLINE void StoreU(const V2x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void StoreU(const V2x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm_storeu_si128(reinterpret_cast<__m128i*>(to), v);
 }
 
 // Writes directly to (aligned) memory, bypassing the cache. This is useful for
 // data that will not be read again in the near future.
-static INLINE void Stream(const V2x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void Stream(const V2x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm_stream_si128(reinterpret_cast<__m128i*>(to), v);
 }
 
 // Miscellaneous functions.
 
-static INLINE V2x64U AndNot(const V2x64U& neg_mask, const V2x64U& values) {
+static HIGHWAYHASH_INLINE
+V2x64U AndNot(const V2x64U& neg_mask, const V2x64U& values) {
   return V2x64U(_mm_andnot_si128(neg_mask, values));
 }
 
-static INLINE V2x64U UnpackLow(const V2x64U& low, const V2x64U& high) {
+static HIGHWAYHASH_INLINE
+V2x64U UnpackLow(const V2x64U& low, const V2x64U& high) {
   return V2x64U(_mm_unpacklo_epi64(low, high));
 }
-static INLINE V2x64U UnpackHigh(const V2x64U& low, const V2x64U& high) {
+static HIGHWAYHASH_INLINE
+V2x64U UnpackHigh(const V2x64U& low, const V2x64U& high) {
   return V2x64U(_mm_unpackhi_epi64(low, high));
 }
 
 // There are no greater-than comparison instructions for unsigned T.
-static INLINE V2x64U operator==(const V2x64U& left, const V2x64U& right) {
+static HIGHWAYHASH_INLINE
+V2x64U operator==(const V2x64U& left, const V2x64U& right) {
   return V2x64U(_mm_cmpeq_epi64(left, right));
 }
 
-static INLINE V2x64U RotateLeft(const V2x64U& v, const int count) {
+static HIGHWAYHASH_INLINE
+V2x64U RotateLeft(const V2x64U& v, const int count) {
   return (v << count) | (v >> (64-count));
 }
 

--- a/highwayhash/vec2.h
+++ b/highwayhash/vec2.h
@@ -42,67 +42,67 @@ class V4x64U {
   static constexpr size_t kNumLanes = sizeof(__m256i) / sizeof(T);
 
   // Leaves v_ uninitialized - typically used for output parameters.
-  INLINE V4x64U() {}
+  HIGHWAYHASH_INLINE V4x64U() {}
 
   // Lane 0 (p_0) is the lowest.
-  INLINE V4x64U(T p_3, T p_2, T p_1, T p_0)
+  HIGHWAYHASH_INLINE V4x64U(T p_3, T p_2, T p_1, T p_0)
       : v_(_mm256_set_epi64x(p_3, p_2, p_1, p_0)) {}
 
   // Broadcasts i to all lanes.
-  INLINE explicit V4x64U(T i)
+  HIGHWAYHASH_INLINE explicit V4x64U(T i)
       : v_(_mm256_broadcastq_epi64(_mm_cvtsi64_si128(i))) {}
 
   // Converts to/from intrinsics.
-  INLINE explicit V4x64U(const __m256i& v) : v_(v) {}
-  INLINE operator __m256i() const { return v_; }
-  INLINE V4x64U& operator=(const __m256i& v) {
+  HIGHWAYHASH_INLINE explicit V4x64U(const __m256i& v) : v_(v) {}
+  HIGHWAYHASH_INLINE operator __m256i() const { return v_; }
+  HIGHWAYHASH_INLINE V4x64U& operator=(const __m256i& v) {
     v_ = v;
     return *this;
   }
 
   // _mm256_setzero_epi64 generates suboptimal code. Instead set
   // z = x - x (given an existing "x"), or x == x to set all bits.
-  INLINE V4x64U& operator=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator=(const V4x64U& other) {
     v_ = other.v_;
     return *this;
   }
 
-  INLINE V4x64U& operator+=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator+=(const V4x64U& other) {
     v_ = _mm256_add_epi64(v_, other);
     return *this;
   }
-  INLINE V4x64U& operator-=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator-=(const V4x64U& other) {
     v_ = _mm256_sub_epi64(v_, other);
     return *this;
   }
 
-  INLINE V4x64U& operator&=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator&=(const V4x64U& other) {
     v_ = _mm256_and_si256(v_, other);
     return *this;
   }
-  INLINE V4x64U& operator|=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator|=(const V4x64U& other) {
     v_ = _mm256_or_si256(v_, other);
     return *this;
   }
-  INLINE V4x64U& operator^=(const V4x64U& other) {
+  HIGHWAYHASH_INLINE V4x64U& operator^=(const V4x64U& other) {
     v_ = _mm256_xor_si256(v_, other);
     return *this;
   }
 
-  INLINE V4x64U& operator<<=(const int count) {
+  HIGHWAYHASH_INLINE V4x64U& operator<<=(const int count) {
     v_ = _mm256_slli_epi64(v_, count);
     return *this;
   }
-  INLINE V4x64U& operator<<=(const __m128i& count) {
+  HIGHWAYHASH_INLINE V4x64U& operator<<=(const __m128i& count) {
     v_ = _mm256_sll_epi64(v_, count);
     return *this;
   }
 
-  INLINE V4x64U& operator>>=(const int count) {
+  HIGHWAYHASH_INLINE V4x64U& operator>>=(const int count) {
     v_ = _mm256_srli_epi64(v_, count);
     return *this;
   }
-  INLINE V4x64U& operator>>=(const __m128i& count) {
+  HIGHWAYHASH_INLINE V4x64U& operator>>=(const __m128i& count) {
     v_ = _mm256_srl_epi64(v_, count);
     return *this;
   }
@@ -113,47 +113,56 @@ class V4x64U {
 
 // Nonmember functions implemented in terms of member functions
 
-static INLINE V4x64U operator+(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator+(const V4x64U& left, const V4x64U& right) {
   V4x64U t(left);
   return t += right;
 }
 
-static INLINE V4x64U operator-(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator-(const V4x64U& left, const V4x64U& right) {
   V4x64U t(left);
   return t -= right;
 }
 
-static INLINE V4x64U operator<<(const V4x64U& v, const int count) {
+static HIGHWAYHASH_INLINE
+V4x64U operator<<(const V4x64U& v, const int count) {
   V4x64U t(v);
   return t <<= count;
 }
 
-static INLINE V4x64U operator>>(const V4x64U& v, const int count) {
+static HIGHWAYHASH_INLINE
+V4x64U operator>>(const V4x64U& v, const int count) {
   V4x64U t(v);
   return t >>= count;
 }
 
-static INLINE V4x64U operator<<(const V4x64U& v, const __m128i& count) {
+static HIGHWAYHASH_INLINE
+V4x64U operator<<(const V4x64U& v, const __m128i& count) {
   V4x64U t(v);
   return t <<= count;
 }
 
-static INLINE V4x64U operator>>(const V4x64U& v, const __m128i& count) {
+static HIGHWAYHASH_INLINE
+V4x64U operator>>(const V4x64U& v, const __m128i& count) {
   V4x64U t(v);
   return t >>= count;
 }
 
-static INLINE V4x64U operator&(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator&(const V4x64U& left, const V4x64U& right) {
   V4x64U t(left);
   return t &= right;
 }
 
-static INLINE V4x64U operator|(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator|(const V4x64U& left, const V4x64U& right) {
   V4x64U t(left);
   return t |= right;
 }
 
-static INLINE V4x64U operator^(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator^(const V4x64U& left, const V4x64U& right) {
   V4x64U t(left);
   return t ^= right;
 }
@@ -161,44 +170,53 @@ static INLINE V4x64U operator^(const V4x64U& left, const V4x64U& right) {
 // Load/Store.
 
 // "from" must be vector-aligned.
-static INLINE V4x64U Load(const uint64* RESTRICT const from) {
+static HIGHWAYHASH_INLINE
+V4x64U Load(const uint64* HIGHWAYHASH_RESTRICT const from) {
   return V4x64U(_mm256_load_si256(reinterpret_cast<const __m256i*>(from)));
 }
 
-static INLINE V4x64U LoadU(const uint64* RESTRICT const from) {
+static HIGHWAYHASH_INLINE
+V4x64U LoadU(const uint64* HIGHWAYHASH_RESTRICT const from) {
   return V4x64U(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(from)));
 }
 
 // "to" must be vector-aligned.
-static INLINE void Store(const V4x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void Store(const V4x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm256_store_si256(reinterpret_cast<__m256i*>(to), v);
 }
 
-static INLINE void StoreU(const V4x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void StoreU(const V4x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(to), v);
 }
 
 // Writes directly to (aligned) memory, bypassing the cache. This is useful for
 // data that will not be read again in the near future.
-static INLINE void Stream(const V4x64U& v, uint64* RESTRICT const to) {
+static HIGHWAYHASH_INLINE
+void Stream(const V4x64U& v, uint64* HIGHWAYHASH_RESTRICT const to) {
   _mm256_stream_si256(reinterpret_cast<__m256i*>(to), v);
 }
 
 // Miscellaneous functions.
 
-static INLINE V4x64U AndNot(const V4x64U& neg_mask, const V4x64U& values) {
+static HIGHWAYHASH_INLINE
+V4x64U AndNot(const V4x64U& neg_mask, const V4x64U& values) {
   return V4x64U(_mm256_andnot_si256(neg_mask, values));
 }
 
-static INLINE V4x64U UnpackLow(const V4x64U& low, const V4x64U& high) {
+static HIGHWAYHASH_INLINE
+V4x64U UnpackLow(const V4x64U& low, const V4x64U& high) {
   return V4x64U(_mm256_unpacklo_epi64(low, high));
 }
-static INLINE V4x64U UnpackHigh(const V4x64U& low, const V4x64U& high) {
+static HIGHWAYHASH_INLINE
+V4x64U UnpackHigh(const V4x64U& low, const V4x64U& high) {
   return V4x64U(_mm256_unpackhi_epi64(low, high));
 }
 
 // There are no greater-than comparison instructions for unsigned T.
-static INLINE V4x64U operator==(const V4x64U& left, const V4x64U& right) {
+static HIGHWAYHASH_INLINE
+V4x64U operator==(const V4x64U& left, const V4x64U& right) {
   return V4x64U(_mm256_cmpeq_epi64(left, right));
 }
 


### PR DESCRIPTION
Prefixing every `#define` with `HIGHWAYHASH_` is a bit unwieldy, but `UNUSED` was causing me build failures when using highwayhash in [Thrill](https://github.com/thrill/thrill), which [has a member function `UNUSED`](https://github.com/thrill/thrill/blob/4ed3d7851a3411814ed0908ab6866a08d27784ae/thrill/common/defines.hpp#L96) in a namespace - this was being `#define`d away by highwayhash, resulting in syntax errors after preprocessing.

I tried to fix style inconsistencies introduced by the search/replacing involved (mostly indentation) but no guarantees. You may want to select a different prefix anyway.