### PR TITLE
Remove macro UNUSED - it's unused.

### DIFF
--- a/highwayhash/code_annotation.h
+++ b/highwayhash/code_annotation.h
@@ -49,16 +49,6 @@
 
 //-----------------------------------------------------------------------------
 
-// Marks a function parameter as unused and avoids
-// the corresponding compiler warning.
-// Wrap around the parameter name, e.g. void f(int UNUSED(x))
-#define UNUSED(param)
-
-// Marks a function local variable or parameter as unused and avoids
-// the corresponding compiler warning.
-// Use instead of UNUSED when the parameter is conditionally unused.
-#define UNUSED2(param) ((void)(param))
-
 #define NONCOPYABLE(className)          \
   className(const className&) = delete; \
   const className& operator=(const className&) = delete;


### PR DESCRIPTION
These `#defines` are not used anywhere in the code.

This fixes my issue when building in Thrill (see #21) in a minimally invasive manner, but for compatibility with other projects, a solution akin to #21 would probably be preferable.