### PR TITLE
Fix for C and musl compatability

### DIFF
--- a/highwayhash/code_annotation.h
+++ b/highwayhash/code_annotation.h
@@ -124,8 +124,10 @@ using crp = T* const RESTRICT;
 // Function taking a reference to an array and returning a pointer to
 // an array of characters. Only declared and never defined; we just
 // need it to determine n, the size of the array that was passed.
+#ifdef __cplusplus
 template <typename T, int n>
 char (*ArraySizeDeducer(T (&)[n]))[n];
+#endif
 
 // Number of elements in an array. Safer than sizeof(name) / sizeof(name[0])
 // because it doesn't compile when a pointer is passed.

--- a/highwayhash/os_specific.cc
+++ b/highwayhash/os_specific.cc
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <cstring>
 #include <random>
 
 #include "highwayhash/code_annotation.h"


### PR DESCRIPTION
C: code_annotation.h is included by the c bindings header file (c_bindings.h -> types.h -> code_annotation.h) but contains an incompatible template statement.
Musl (https://www.musl-libc.org/): Musl sticks to the POSIX standard. Therefore memset() is only available after string.h/cstring is included.