### PR TITLE
Add SipHash13

### DIFF
--- a/highwayhash/c_bindings.h
+++ b/highwayhash/c_bindings.h
@@ -6,11 +6,15 @@
 #include "third_party/highwayhash/highwayhash/types.h"
 
 uint64 SipHashC(const uint64* key, const char* bytes, const uint64 size);
+uint64 SipHash13C(const uint64* key, const char* bytes, const uint64 size);
 
 uint64 ScalarSipTreeHashC(const uint64* key, const char* bytes,
                           const uint64 size);
+uint64 ScalarSipTreeHash13C(const uint64* key, const char* bytes,
+                          const uint64 size);
 
 uint64 SipTreeHashC(const uint64* key, const char* bytes, const uint64 size);
+uint64 SipTreeHash13C(const uint64* key, const char* bytes, const uint64 size);
 
 uint64 ScalarHighwayTreeHashC(const uint64* key, const char* bytes,
                               const uint64 size);

--- a/highwayhash/scalar_sip_tree_hash.h
+++ b/highwayhash/scalar_sip_tree_hash.h
@@ -26,6 +26,8 @@ extern "C" {
 
 uint64 ScalarSipTreeHash(const uint64 (&key)[4], const char* bytes,
                          const uint64 size);
+uint64 ScalarSipTreeHash13(const uint64 (&key)[4], const char* bytes,
+                         const uint64 size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/highwayhash/sip_hash.cc
+++ b/highwayhash/sip_hash.cc
@@ -14,14 +14,30 @@
 
 #include "third_party/highwayhash/highwayhash/sip_hash.h"
 
+namespace highwayhash {
+uint64 SipHash(const SipHashState::Key& key, const char* bytes,
+                                const uint64 size) {
+  return ComputeHash<SipHashStateImp<2,4>>(key, bytes, size);
+}
+uint64 SipHash13(const SipHash13State::Key& key, const char* bytes,
+                                const uint64 size) {
+  return ComputeHash<SipHashStateImp<1,3>>(key, bytes, size);
+}
+}
 using highwayhash::uint64;
 using highwayhash::SipHash;
+using highwayhash::SipHash13;
 using Key = highwayhash::SipHashState::Key;
+using Key13 = highwayhash::SipHash13State::Key;
 
 extern "C" {
 
 uint64 SipHashC(const uint64* key, const char* bytes, const uint64 size) {
   return SipHash(*reinterpret_cast<const Key*>(key), bytes, size);
+}
+
+uint64 SipHash13C(const uint64* key, const char* bytes, const uint64 size) {
+  return SipHash13(*reinterpret_cast<const Key13*>(key), bytes, size);
 }
 
 }  // extern "C"

--- a/highwayhash/sip_hash_main.cc
+++ b/highwayhash/sip_hash_main.cc
@@ -194,6 +194,12 @@ void RunTests(int argc, char* argv[]) {
                     return SipHash(key2, in, size);
                   });
 
+  AddMeasurements(in_sizes, "SipHash13", &measurements,
+                  [&key2](const size_t size) {
+                    char in[1024] = {static_cast<char>(size)};
+                    return SipHash13(key2, in, size);
+                  });
+
 #ifdef __AVX2__
   {
     uint64 key4[4] = {0, 1, 2, 3};
@@ -201,6 +207,12 @@ void RunTests(int argc, char* argv[]) {
                     [&key4](const size_t size) {
                       char in[1024] = {static_cast<char>(size)};
                       return SipTreeHash(key4, in, size);
+                    });
+
+    AddMeasurements(in_sizes, "SipTreeHash13", &measurements,
+                    [&key4](const size_t size) {
+                      char in[1024] = {static_cast<char>(size)};
+                      return SipTreeHash13(key4, in, size);
                     });
 
     AddMeasurements(in_sizes, "HighwayTreeHash", &measurements,
@@ -230,6 +242,7 @@ void RunTests(int argc, char* argv[]) {
 #endif
 #ifdef __AVX2__
   VerifyEqual("SipTreeHash", ScalarSipTreeHash, SipTreeHash);
+  VerifyEqual("SipTreeHash13", ScalarSipTreeHash13, SipTreeHash13);
   VerifyEqual("HighwayTreeHash", ScalarHighwayTreeHash, HighwayTreeHash);
 #endif
 }

--- a/highwayhash/sip_tree_hash.h
+++ b/highwayhash/sip_tree_hash.h
@@ -42,6 +42,9 @@ extern "C" {
 uint64 SipTreeHash(const uint64 (&key)[4], const char* bytes,
                    const uint64 size);
 
+uint64 SipTreeHash13(const uint64 (&key)[4], const char* bytes,
+                   const uint64 size);
+
 #ifdef __cplusplus
 }  // extern "C"
 }  // namespace highwayhash


### PR DESCRIPTION
For #30 

SipHash13 is secure enough to be used as a hash function in a hash table.
SipTreeHash13 is comparable in performance to non-tree HighwayHash.

It has no practically usable attack as a MAC, but has "theoretically
usable" distinguisher. So that, it's use as a secure MAC is not
recommended.