### PR TITLE
Add missing include

### DIFF
--- a/highwayhash/vector_test.cc
+++ b/highwayhash/vector_test.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <cstdio>
 
 #ifdef HH_GOOGLETEST
 #include "testing/base/public/gmock.h"


### PR DESCRIPTION
This should make the `vector_test` compile again.