### PR TITLE
Initial realisation of affinity for Mac OS X

### DIFF
--- a/highwayhash/os_mac.cc
+++ b/highwayhash/os_mac.cc
@@ -1,0 +1,33 @@
+//
+// Created by Alexander Gryanko on 16/09/2017.
+//
+
+#include "os_mac.h"
+
+int mac_getaffinity(cpu_set_t* set) {
+  uint16_t core_count = 0;
+  size_t core_count_size = sizeof(core_count); // size is a pointer
+  const int err = sysctlbyname(__SYSCTL_CORE_COUNT, &core_count,
+                                 &core_count_size, 0, 0);
+  if (err != 0)
+    return err;
+
+  CPU_ZERO(set);
+  for (uint16_t i = 0; i < core_count; ++i) {
+    CPU_SET(i, set);
+  }
+
+  return 0;
+}
+
+int mac_setaffinity(cpu_set_t* set) {
+  thread_port_t thread = pthread_mach_thread_np(pthread_self());
+
+  uint16_t current_core;
+  for (current_core = 0; current_core < __NR_CPUS; ++current_core) {
+    if (CPU_ISSET(current_core, set)) break;
+  }
+  thread_affinity_policy_data_t policy = { current_core };
+  return thread_policy_set(thread, THREAD_AFFINITY_POLICY,
+                                                (thread_policy_t)&policy, 1);
+}

--- a/highwayhash/os_mac.cc
+++ b/highwayhash/os_mac.cc
@@ -5,15 +5,15 @@
 #include "os_mac.h"
 
 int mac_getaffinity(cpu_set_t* set) {
-  uint16_t core_count = 0;
+  int64_t core_count = 0;
   size_t core_count_size = sizeof(core_count); // size is a pointer
   const int err = sysctlbyname(__SYSCTL_CORE_COUNT, &core_count,
-                                 &core_count_size, 0, 0);
+                                 &core_count_size, NULL, 0);
   if (err != 0)
     return err;
 
   CPU_ZERO(set);
-  for (uint16_t i = 0; i < core_count; ++i) {
+  for (int64_t i = 0; i < core_count; ++i) {
     CPU_SET(i, set);
   }
 

--- a/highwayhash/os_mac.h
+++ b/highwayhash/os_mac.h
@@ -1,0 +1,54 @@
+//
+// Created by Alexander Gryanko on 16/09/2017.
+//
+
+#ifndef HIGHWAYHASH_OS_MAC_H_
+#define HIGHWAYHASH_OS_MAC_H_
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <sys/sysctl.h>
+
+#include <mach/mach_types.h>
+#include <mach/thread_act.h>
+#include <pthread.h>
+
+
+typedef unsigned long int __cpu_mask;
+
+#define __SYSCTL_CORE_COUNT "machdep.cpu.core_count"
+#define __NR_CPUS 512 // from the linux kernel limit
+#define __NR_CPUBITS (8 * sizeof(__cpu_mask))
+
+typedef struct
+{
+  __cpu_mask __bits[__NR_CPUS / __NR_CPUBITS];
+} cpu_set_t;
+
+static inline void __CPU_ZERO(size_t setsize, cpu_set_t* set) {
+  memset(set, 0, setsize);
+}
+#define CPU_ZERO(cpusetp) __CPU_ZERO(sizeof(cpu_set_t), cpusetp)
+
+static inline int __CPU_ISSET(int cpu, size_t setsize, const cpu_set_t* set) {
+  if (cpu < 8 * setsize) {
+    return (set->__bits[cpu / __NR_CPUBITS] & 1 << (cpu % __NR_CPUBITS)) != 0;
+  }
+  return 0;
+}
+#define CPU_ISSET(cpu, cpusetp) __CPU_ISSET(cpu, sizeof(cpu_set_t), cpusetp)
+
+static inline void __CPU_SET(int cpu, size_t setsize, cpu_set_t* set) {
+  if (cpu < 8 * setsize) {
+    set->__bits[cpu / __NR_CPUBITS] |= 1 << (cpu % __NR_CPUBITS);
+  }
+}
+#define CPU_SET(cpu, cpusetp) __CPU_SET(cpu, sizeof(cpu_set_t), cpusetp)
+
+int mac_getaffinity(cpu_set_t* set);
+int mac_setaffinity(cpu_set_t* set);
+
+#endif // HIGHWAYHASH_OS_MAC_H_
+
+

--- a/highwayhash/os_mac.h
+++ b/highwayhash/os_mac.h
@@ -17,7 +17,7 @@
 
 typedef unsigned long int __cpu_mask;
 
-#define __SYSCTL_CORE_COUNT "machdep.cpu.core_count"
+#define __SYSCTL_CORE_COUNT "machdep.cpu.thread_count"
 #define __NR_CPUS 512 // from the linux kernel limit
 #define __NR_CPUBITS (8 * sizeof(__cpu_mask))
 
@@ -31,20 +31,18 @@ static inline void __CPU_ZERO(size_t setsize, cpu_set_t* set) {
 }
 #define CPU_ZERO(cpusetp) __CPU_ZERO(sizeof(cpu_set_t), cpusetp)
 
-static inline int __CPU_ISSET(int cpu, size_t setsize, const cpu_set_t* set) {
-  if (cpu < 8 * setsize) {
-    return (set->__bits[cpu / __NR_CPUBITS] & 1 << (cpu % __NR_CPUBITS)) != 0;
+static inline int CPU_ISSET(int cpu, const cpu_set_t* set) {
+  if (cpu < __NR_CPUS) {
+    return (set->__bits[cpu / __NR_CPUBITS] & 1L << (cpu % __NR_CPUBITS)) != 0;
   }
   return 0;
 }
-#define CPU_ISSET(cpu, cpusetp) __CPU_ISSET(cpu, sizeof(cpu_set_t), cpusetp)
 
-static inline void __CPU_SET(int cpu, size_t setsize, cpu_set_t* set) {
-  if (cpu < 8 * setsize) {
-    set->__bits[cpu / __NR_CPUBITS] |= 1 << (cpu % __NR_CPUBITS);
+static inline void CPU_SET(int cpu, cpu_set_t* set) {
+  if (cpu < __NR_CPUS) {
+    set->__bits[cpu / __NR_CPUBITS] |= 1L << (cpu % __NR_CPUBITS);
   }
 }
-#define CPU_SET(cpu, cpusetp) __CPU_SET(cpu, sizeof(cpu_set_t), cpusetp)
 
 int mac_getaffinity(cpu_set_t* set);
 int mac_setaffinity(cpu_set_t* set);


### PR DESCRIPTION
OS X has no affinity pinning API in libc. Small workaround based on glibc Linux implementation.

Tested with this hack:

```
int mac_setaffinity(cpu_set_t* set) {
  thread_port_t thread = pthread_mach_thread_np(pthread_self());

  uint16_t current_core;
  for (current_core = 0; current_core < __NR_CPUS; ++current_core) {
    if (CPU_ISSET(current_core, set)) break;
  }
    thread_affinity_policy_data_t current_policy;
    mach_msg_type_number_t policy_count = THREAD_AFFINITY_POLICY_COUNT;
    boolean_t get_default = FALSE;
  thread_policy_get(thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&current_policy, &policy_count, &get_default);
    printf("%d\n", current_policy);
  thread_affinity_policy_data_t policy = { current_core };
    printf("set %d\n", policy);
  int err = thread_policy_set(thread, THREAD_AFFINITY_POLICY,
                                                (thread_policy_t)&policy, 1);
    thread_policy_get(thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&current_policy, &policy_count, &get_default);
    printf("get %d\n", current_policy);
    return err;
}
```

> 0
set 2
get 2
Running on CPU #2, APIC ID 01
2
set 0
get 0
0
set 1
get 1
1
set 2
get 2
2
set 3
get 3
3
set 0
get 0
Resolution 66
NumReplicas 185
    3: median= 81.65 ticks; median abs. deviation= 0.454 ticks
    4: median= 77.59 ticks; median abs. deviation= 1.646 ticks
    7: median= 83.92 ticks; median abs. deviation= 0.968 ticks
    8: median= 78.34 ticks; median abs. deviation= 1.227 ticks