### PR TITLE
Fix cast problems

### DIFF
--- a/highwayhash/hh_portable.h
+++ b/highwayhash/hh_portable.h
@@ -65,7 +65,7 @@ class HHStatePortable {
     // 'Length padding' differentiates zero-valued inputs that have the same
     // size/32. mod32 is sufficient because each Update behaves as if a
     // counter were injected, because the state is large and mixed thoroughly.
-    const uint64_t mod32_pair = (size_mod32 << 32) + size_mod32;
+    const uint64_t mod32_pair = (static_cast<uint64_t>(size_mod32) << 32) + size_mod32;
     for (int lane = 0; lane < kNumLanes; ++lane) {
       v0[lane] += mod32_pair;
     }

--- a/highwayhash/load3.h
+++ b/highwayhash/load3.h
@@ -93,9 +93,9 @@ class Load3 {
     const uint64_t idx1 = size_mod4 >> 1;
     const uint64_t idx2 = size_mod4 - 1;
     // Store into least significant bytes (avoids one shift).
-    last3 = static_cast<uint64_t>(from[idx0]);
-    last3 += static_cast<uint64_t>(from[idx1]) << 8;
-    last3 += static_cast<uint64_t>(from[idx2]) << 16;
+    last3 = U64FromChar(from[idx0]);
+    last3 += U64FromChar(from[idx1]) << 8;
+    last3 += U64FromChar(from[idx2]) << 16;
     return last3;
   }
 


### PR DESCRIPTION
1. static_cast from char to uint64_t is probably not what we want. The underlying type of char is signed char on x86/64 platform. When the input byte is negative, the casting result will be padded by '1's. This is why this c++ version cannot pass the unit test of the c implementation. After replacing it with U64FromChar, the results from these 2 versions are identical. This error will lead to wrong results for most of the random inputs. I'm really surprised it's not discovered by c++ version's unit test. 

2. size_t shift by 32 bits is undefined behavior for 32-bit applications.  