### PR TITLE
Fix my mistakes.

### DIFF
--- a/highwayhash/hh_neon.h
+++ b/highwayhash/hh_neon.h
@@ -74,7 +74,11 @@ class HHStateNEON {
     // 'Length padding' differentiates zero-valued inputs that have the same
     // size/32. mod32 is sufficient because each Update behaves as if a
     // counter were injected, because the state is large and mixed thoroughly.
-    const int32x4_t vsize_mod32(static_cast<int32_t>(size_mod32));
+
+    // We can't use vshl/vsra because it needs a constant expression.
+    // In order to do this right now, we would need a switch statement.
+    const int32x4_t vsize_mod32(vdupq_n_s32(static_cast<int32_t>(size_mod32)));
+    // -32 - size_mod32
     const int32x4_t shift_right_amt = vdupq_n_s32(static_cast<int32_t>(size_mod32) + (~32 + 1));
     // Equivalent to storing size_mod32 in packet.
     v0L += V2x64U(vreinterpretq_u64_s32(vsize_mod32));

--- a/highwayhash/os_mac.h
+++ b/highwayhash/os_mac.h
@@ -39,7 +39,7 @@ struct cpu_set_t {
 };
 
 static inline void CPU_ZERO(size_t setsize, cpu_set_t* set) {
-  memset(set, 0, setsize);
+  memset(set, 0, sizeof(cpu_set_t));
 }
 
 static inline int CPU_ISSET(int cpu, const cpu_set_t* set) {

--- a/highwayhash/vector_neon.h
+++ b/highwayhash/vector_neon.h
@@ -114,7 +114,7 @@ HH_INLINE uint64x2_t vld1q_low_u64(const uint64_t* p)
 #define EXPAND(...) __VA_ARGS__
 
 #define CASE(op, i, ...)                   \
-    case i: v_ = op(__VA_ARGS__, i);
+    case i: v_ = op(__VA_ARGS__, i); break;
 
 #define INTRINSIC_REPEAT_8_0(op, addx, ...)    \
     CASE(EXPAND(op), 1 + addx, __VA_ARGS__);       \
@@ -176,7 +176,7 @@ class V128<uint8_t> {
   HH_INLINE explicit V128(T i) : v_(vdupq_n_u8(i)) {}
 
   // Copy from other vector.
-  HH_INLINE explicit V128(const V128& other) : v_(other.v_) {}
+  HH_INLINE explicit V128(const V128& other) : v_(wother.v_) {}
 
   // C-style cast because vector casts are stupid on NEON.
   template <typename U>
@@ -356,7 +356,7 @@ class V128<uint32_t> {
   // Copy from other vector.
   HH_INLINE explicit V128(const V128& other) : v_(other.v_) {}
   template <typename U>
-  HH_INLINE explicit V128(const V128<U>& other) : v_((const uint32x4_t)other.v_) {}
+  HH_INLINE explicit V128(const V128<U>& other) : v_((const uint32x4_t)other) {}
   HH_INLINE V128& operator=(const V128& other) {
     v_ = other.v_;
     return *this;
@@ -881,12 +881,13 @@ HH_INLINE void Store<uint32_t>(const V128<uint32_t>& v, uint32_t* const HH_RESTR
   vst1q_u32(p, v);
 }
 
-#undef HH_ALIGN
 template<>
 HH_INLINE void Store<uint64_t>(const V128<uint64_t>& v, uint64_t* const HH_RESTRICT to) {
   uint64_t *const HH_RESTRICT p = reinterpret_cast<uint64_t *>(HH_ALIGN(to));
   vst1q_u64(p, v);
 }
+#undef HH_ALIGN
+
 #if 0
 HH_INLINE void Store(const V128<float>& v, float* const HH_RESTRICT to) {
   vst1q_f32(to, v);

--- a/highwayhash/vector_neon.h
+++ b/highwayhash/vector_neon.h
@@ -176,7 +176,7 @@ class V128<uint8_t> {
   HH_INLINE explicit V128(T i) : v_(vdupq_n_u8(i)) {}
 
   // Copy from other vector.
-  HH_INLINE explicit V128(const V128& other) : v_(wother.v_) {}
+  HH_INLINE explicit V128(const V128& other) : v_(other.v_) {}
 
   // C-style cast because vector casts are stupid on NEON.
   template <typename U>


### PR DESCRIPTION
I accidentally committed a working copy which had a few errors instead of the version I had tested thoroughly. 

Fixed:
 - Remove argument from CPU_SET function that was causing issues.
 - Fix private member access in vector_neon.h
 - Fix a macro that was #undef'd too early
 - Fixed a missing vdupq_n_s32 in UpdateRemainder
 - Fixed a missing break statement in the CASE macro

I am sorry about that. 