### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/highwayhash/hh_neon.h
+++ b/highwayhash/hh_neon.h
@@ -38,7 +38,7 @@ namespace highwayhash {
 // it easier use the vector_neon symbols, but requires textual inclusion.
 namespace HH_TARGET_NAME {
 
-// J-lanes tree hashing: see http://dx.doi.org/10.4236/jis.2014.53010
+// J-lanes tree hashing: see https://doi.org/10.4236/jis.2014.53010
 // Uses the same method that SSE4.1 uses, only with NEON used instead.
 class HHStateNEON {
  public:

--- a/highwayhash/hh_sse41.h
+++ b/highwayhash/hh_sse41.h
@@ -36,7 +36,7 @@ namespace highwayhash {
 // it easier use the vector128 symbols, but requires textual inclusion.
 namespace HH_TARGET_NAME {
 
-// J-lanes tree hashing: see http://dx.doi.org/10.4236/jis.2014.53010
+// J-lanes tree hashing: see https://doi.org/10.4236/jis.2014.53010
 // Uses pairs of SSE4.1 instructions to emulate the AVX-2 algorithm.
 class HHStateSSE41 {
  public:

--- a/highwayhash/hh_vsx.h
+++ b/highwayhash/hh_vsx.h
@@ -81,7 +81,7 @@ static HH_INLINE PPC_VEC_U64 MultiplyVectors(const PPC_VEC_U64& vec1,
                   reinterpret_cast<const PPC_VEC_U32>(vec2));
 }
 
-// J-lanes tree hashing: see http://dx.doi.org/10.4236/jis.2014.53010
+// J-lanes tree hashing: see https://doi.org/10.4236/jis.2014.53010
 class HHStateVSX {
  public:
   explicit HH_INLINE HHStateVSX(const HHKey key) { Reset(key); }

--- a/highwayhash/scalar_sip_tree_hash.cc
+++ b/highwayhash/scalar_sip_tree_hash.cc
@@ -25,7 +25,7 @@ namespace {
 
 // Paper: https://www.131002.net/siphash/siphash.pdf
 // SSE41 implementation: https://goo.gl/80GBSD
-// Tree hash extension: http://dx.doi.org/10.4236/jis.2014.53010
+// Tree hash extension: https://doi.org/10.4236/jis.2014.53010
 
 // The hash state is updated by injecting 4x8-byte packets;
 // XORing together all state vectors yields 32 bytes that are

--- a/highwayhash/sip_tree_hash.cc
+++ b/highwayhash/sip_tree_hash.cc
@@ -28,7 +28,7 @@ namespace {
 
 // Paper: https://www.131002.net/siphash/siphash.pdf
 // SSE41 implementation: https://goo.gl/80GBSD
-// Tree hash extension: http://dx.doi.org/10.4236/jis.2014.53010
+// Tree hash extension: https://doi.org/10.4236/jis.2014.53010
 
 // The hash state is updated by injecting 4x8-byte packets;
 // XORing together all state vectors yields 32 bytes that are


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!