### PR TITLE
Fix build on FreeBSD/powerpc64

### DIFF
--- a/highwayhash/arch_specific.cc
+++ b/highwayhash/arch_specific.cc
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
+#endif
 
 #include <string.h>  // memcpy
 #include <string>

--- a/highwayhash/arch_specific.cc
+++ b/highwayhash/arch_specific.cc
@@ -21,7 +21,11 @@
 #endif
 
 #if HH_ARCH_PPC
+#if __GLIBC__
 #include <sys/platform/ppc.h>  // __ppc_get_timebase_freq
+#elif __FreeBSD__
+#include <sys/types.h>
+#include <sys/sysctl.h>
 #endif
 
 #include <string.h>  // memcpy
@@ -118,6 +122,7 @@ double DetectNominalClockRate() {
   }
 #elif HH_ARCH_PPC
   double freq = -1;
+#if __linux__
   char line[200];
   char* s;
   char* value;
@@ -142,6 +147,12 @@ double DetectNominalClockRate() {
     fclose(f);
     return freq;
   }
+ #elif __FreeBSD__
+  size_t length = sizeof(freq);
+  sysctlbyname("dev.cpu.0.freq"), &freq, &length, NULL, 0);
+  freq *= 1E6;
+  return freq;
+#endif
 #endif
 
   return 0.0;
@@ -157,7 +168,13 @@ double NominalClockRate() {
 
 double InvariantTicksPerSecond() {
 #if HH_ARCH_PPC
+#if __GLIBC__  
   static const double cycles_per_second = __ppc_get_timebase_freq();
+#elif __FreeBSD__
+  static double cycles_per_second = 0;
+  size_t length = sizeof(cycles_per_second);
+  sysctlbyname("kern.timecounter.tc.timebase.frequency", &cycles_per_second, &length, NULL, 0);
+#endif
   return cycles_per_second;
 #else
   return NominalClockRate();

--- a/highwayhash/os_specific.cc
+++ b/highwayhash/os_specific.cc
@@ -51,8 +51,8 @@
 
 #ifdef __FreeBSD__
 #define OS_FREEBSD 1
-#include <sys/cpuset.h>
 #include <sys/param.h>
+#include <sys/cpuset.h>
 #include <unistd.h>
 #else
 #define OS_FREEBSD 0


### PR DESCRIPTION
sys/platform/ppc.h is glibc-specific.
Only Linux has /proc/cpuinfo.

sys/cpuset.h needs to be included after sys/param.h.