### PR TITLE
Add link to Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ By | Language | URL
 --- | --- | ---
 Damian Gryski | Go and x64 assembly | https://github.com/dgryski/go-highway/
 Lovell Fuller | node.js bindings | https://github.com/lovell/highwayhash
+Nick Babcock | Rust port | https://github.com/nickbabcock/highway-rs
 Vinzent Steinberg | Rust bindings | https://github.com/vks/highwayhash-rs
 Frank Wessels & Andreas Auernhammer | Go and ARM assembly | https://github.com/minio/highwayhash
 Phil Demetriou | Python 3 bindings | https://github.com/kpdemetriou/highwayhash-cffi


### PR DESCRIPTION
This should probably replace my out-of-date crate with the Rust bindings.