### PR TITLE
Enable SSE4 when AVX is enabled (MSVC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Nick Babcock | Rust port | https://github.com/nickbabcock/highway-rs
 Vinzent Steinberg | Rust bindings | https://github.com/vks/highwayhash-rs
 Frank Wessels & Andreas Auernhammer | Go and ARM assembly | https://github.com/minio/highwayhash
 Phil Demetriou | Python 3 bindings | https://github.com/kpdemetriou/highwayhash-cffi
+Jonathan Beard | C++20 constexpr | https://gist.github.com/jonathan-beard/632017faa1d9d1936eb5948ac9186657
 
 ## Modules
 

--- a/highwayhash/arch_specific.h
+++ b/highwayhash/arch_specific.h
@@ -90,7 +90,10 @@ namespace highwayhash {
 // match the HH_TARGET_* suffixes below.
 #ifdef __AVX2__
 #define HH_TARGET_NAME AVX2
-#elif defined(__SSE4_1__)
+// MSVC does not set SSE4_1, but it does set AVX; checking for the latter means
+// we at least get SSE4 on machines supporting AVX but not AVX2.
+// https://stackoverflow.com/questions/18563978/detect-the-availability-of-sse-sse2-instruction-set-in-visual-studio
+#elif defined(__SSE4_1__) || (HH_MSC_VERSION != 0 && defined(__AVX__))
 #define HH_TARGET_NAME SSE41
 #elif defined(__VSX__)
 #define HH_TARGET_NAME VSX

--- a/highwayhash/sip_hash_test.cc
+++ b/highwayhash/sip_hash_test.cc
@@ -97,18 +97,16 @@ char* GetInput(size_t size) {
 }
 
 template <class Hasher>
-void BM(int iters, int size) {
-  StopBenchmarkTiming();
+void BM(benchmark::State& state) {
+  int size = state.range(0);
   auto* input = GetInput(size);
   const HH_U64 keys[4] = {0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL,
                           0x1716151413121110ULL, 0x1F1E1D1C1B1A1918ULL};
   Hasher hasher(keys);
-  StartBenchmarkTiming();
-  for (int i = 0; i < iters; ++i) {
-    testing::DoNotOptimize(hasher(input, size));
+  for (auto s : state) {
+    benchmark::DoNotOptimize(hasher(input, size));
   }
-  StopBenchmarkTiming();
-  SetBenchmarkBytesProcessed(static_cast<int64>(iters) * size);
+  state.SetBytesProcessed(state.iterations() * size);
 }
 
 void Args(::testing::Benchmark* bm) {


### PR DESCRIPTION
Fixes #96, thank you @andrewevstyukhin for reporting.

Also sync implementation list and update benchmark.