### PR TITLE
sys/cpuset.h must be included after sys/param.h (FreeBSD)

### DIFF
--- a/highwayhash/os_specific.cc
+++ b/highwayhash/os_specific.cc
@@ -53,8 +53,10 @@
 
 #ifdef __FreeBSD__
 #define OS_FREEBSD 1
-#include <sys/cpuset.h>
+// clang-format off
 #include <sys/param.h>
+#include <sys/cpuset.h>			/* must come after sys/param.h */
+// clang-format on
 #include <unistd.h>
 #else
 #define OS_FREEBSD 0


### PR DESCRIPTION
According to the cpuset(2) man page, sys/param.h must be included before sys/cpuset.h. This was fixed in May of 2020 (bac1f23) and undone in August of 2020 (9490b14).

Here's a log showing the compile errors under FreeBSD 14.0-CURRENT:

    http://beefy18.nyi.freebsd.org/data/main-amd64-default/pf44e1c1de734_s63ca9ea4f3/logs/zeek-4.0.3.log

Fix the order again. While we're here add a comment and disable clang-format for these includes.

Thanks to @skand888 for analyzing the FreeBSD build failure which brought me here.