### PR TITLE
sys/sysctl.h must be included after sys/types.h (FreeBSD)

### DIFF
--- a/highwayhash/arch_specific.cc
+++ b/highwayhash/arch_specific.cc
@@ -24,8 +24,10 @@
 #if __GLIBC__
 #include <sys/platform/ppc.h>  // __ppc_get_timebase_freq
 #elif __FreeBSD__
-#include <sys/sysctl.h>
+// clang-format off
 #include <sys/types.h>
+#include <sys/sysctl.h>                 /* must come after sys/types.h */
+// clang-format on
 #endif
 #endif
 


### PR DESCRIPTION
According to the sysctl(3) man page, sys/types.h must be included before sys/sysctl.h. This is another casualty of the August of 2020 (9490b14) autoformatter update.

Here's the compile error (powerpc64*) from the [commit](https://cgit.freebsd.org/ports/commit/?id=b91d1bd03771d45095637061c58baba5e62fc991) made by Piotr Kubaj that patched the FreeBSD security/zeek port:

    In file included from /wrkdirs/usr/ports/security/zeek/work/zeek-4.0.3/auxil/highwayhash/highwayhash/arch_specific.cc:27:
    /usr/include/sys/sysctl.h:1185:25: error: unknown type name 'u_int'
    int     sysctl(const int *, u_int, void *, size_t *, const void *, size_t);

As with https://github.com/google/highwayhash/pull/99, add a comment and disable clang-format for these includes.