### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/highwayhash/os_specific.cc
+++ b/highwayhash/os_specific.cc
@@ -40,7 +40,7 @@
 #define OS_LINUX 0
 #endif
 
-#if defined(__APPLE__) || \
+#if defined(__APPLE__) && \
     defined(__MACH__)  // __MACH__ also defined for GNU/Hurd
 #define OS_MAC 1
 #include <mach/mach.h>


### PR DESCRIPTION
Not sure what the intention of the check was here, as all this does is trigger if __MACH__ is defined (OSX or Hurd), OR if __APPLE__ is defined (OSX), and then say that this is macos. Anyways, fixed to only define OS_MAC if the OS is actually Mac.