### PR TITLE
Fix build on gcc 12

### DIFF
--- a/highwayhash/benchmark.cc
+++ b/highwayhash/benchmark.cc
@@ -141,7 +141,7 @@ class Measurements {
     return sizes;
   }
 
-  using SpeedsForCaption = absl::btree_map<std::string, std::vector<float>>;
+  using SpeedsForCaption = std::map<std::string, std::vector<float>>;
 
   SpeedsForCaption SortByCaption() const {
     SpeedsForCaption cpb_for_caption;


### PR DESCRIPTION
fix #111 

I run you inner benchmarks and all passed. 

``` bash
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./benchmark 
Resolution 72
NumReplicas 253
HighwayHashAVX2    7: median=  83.5 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2    8: median=  83.8 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2   31: median=  82.7 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2   32: median=  79.8 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2   63: median=  91.2 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2   64: median=  85.2 ticks; median L1 norm = 0.1 ticks
HighwayHashAVX2 1024: median= 289.1 ticks; median L1 norm = 0.2 ticks
NumReplicas 252
HighwayHashSSE41    7: median=  83.6 ticks; median L1 norm = 0.4 ticks
HighwayHashSSE41    8: median=  84.2 ticks; median L1 norm = 0.4 ticks
HighwayHashSSE41   31: median=  85.4 ticks; median L1 norm = 0.4 ticks
HighwayHashSSE41   32: median=  75.3 ticks; median L1 norm = 0.6 ticks
HighwayHashSSE41   63: median=  89.7 ticks; median L1 norm = 0.6 ticks
HighwayHashSSE41   64: median=  83.3 ticks; median L1 norm = 0.6 ticks
HighwayHashSSE41 1024: median= 357.4 ticks; median L1 norm = 0.9 ticks
NumReplicas 41
HighwayHashPortable    7: median= 417.1 ticks; median L1 norm = 1.8 ticks
HighwayHashPortable    8: median= 416.2 ticks; median L1 norm = 1.8 ticks
HighwayHashPortable   31: median= 419.7 ticks; median L1 norm = 1.8 ticks
HighwayHashPortable   32: median= 414.4 ticks; median L1 norm = 1.8 ticks
HighwayHashPortable   63: median= 518.9 ticks; median L1 norm = 0.9 ticks
HighwayHashPortable   64: median= 485.6 ticks; median L1 norm = 0.9 ticks
HighwayHashPortable 1024: median=2333.9 ticks; median L1 norm = 1.8 ticks
NumReplicas 213
HighwayHashCatAVX2    7: median= 109.9 ticks; median L1 norm = 0.2 ticks
HighwayHashCatAVX2    8: median= 103.8 ticks; median L1 norm = 0.2 ticks
HighwayHashCatAVX2   31: median= 102.9 ticks; median L1 norm = 0.2 ticks
HighwayHashCatAVX2   32: median= 100.4 ticks; median L1 norm = 0.2 ticks
HighwayHashCatAVX2   63: median= 114.4 ticks; median L1 norm = 0.2 ticks
HighwayHashCatAVX2   64: median= 103.1 ticks; median L1 norm = 0.1 ticks
HighwayHashCatAVX2 1024: median= 313.5 ticks; median L1 norm = 0.2 ticks
NumReplicas 184
HighwayHashCatSSE41    7: median=  98.3 ticks; median L1 norm = 0.5 ticks
HighwayHashCatSSE41    8: median=  93.3 ticks; median L1 norm = 0.6 ticks
HighwayHashCatSSE41   31: median=  96.7 ticks; median L1 norm = 0.7 ticks
HighwayHashCatSSE41   32: median= 103.1 ticks; median L1 norm = 0.4 ticks
HighwayHashCatSSE41   63: median= 166.5 ticks; median L1 norm = 0.8 ticks
HighwayHashCatSSE41   64: median=  95.9 ticks; median L1 norm = 0.6 ticks
HighwayHashCatSSE41 1024: median= 367.3 ticks; median L1 norm = 0.5 ticks
NumReplicas 38
HighwayHashCatPortable    7: median= 488.8 ticks; median L1 norm = 1.9 ticks
HighwayHashCatPortable    8: median= 481.3 ticks; median L1 norm = 1.9 ticks
HighwayHashCatPortable   31: median= 475.6 ticks; median L1 norm = 0.9 ticks
HighwayHashCatPortable   32: median= 495.5 ticks; median L1 norm = 1.9 ticks
HighwayHashCatPortable   63: median= 591.2 ticks; median L1 norm = 1.9 ticks
HighwayHashCatPortable   64: median= 542.8 ticks; median L1 norm = 1.9 ticks
HighwayHashCatPortable 1024: median=2371.7 ticks; median L1 norm = 2.4 ticks
\begin{tabular}{r|r|r|r|r|r|r|r}
\toprule
Algorithm & 7 & 8 & 31 & 32 & 63 & 64 & 1024\\
\midrule
       HighwayHashAVX2 &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
    HighwayHashCatAVX2 &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
HighwayHashCatPortable &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
   HighwayHashCatSSE41 &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
   HighwayHashPortable &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
      HighwayHashSSE41 &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan &  -nan\\
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./highwayhash_test 
Mismatch at size 33 for target Portable
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./sip_hash_test 
VerifySipHash succeeded.
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./vector_test 
  Portable: done
     SSE41: done
      AVX2: done
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./
benchmark              nanobenchmark_example  sip_hash_test
highwayhash_test       profiler_example       vector_test
andrei@X570-GAMING-X:~/gitHub/highwayhash/bin$ ./nanobenchmark_example 
Running on CPU #11, APIC ID 0d
Resolution 72
NumReplicas 946
    3: median= 20.84 ticks; median abs. deviation= 0.190 ticks
    4: median= 26.70 ticks; median abs. deviation= 0.171 ticks
    7: median= 27.17 ticks; median abs. deviation= 0.400 ticks
    8: median= 35.24 ticks; median abs. deviation= 0.342 ticks
```