### PR TITLE
Disable SSE, AVX and AVX2 and FMA flags if OS has XSAVE disabled

### DIFF
--- a/highwayhash/instruction_sets.cc
+++ b/highwayhash/instruction_sets.cc
@@ -92,6 +92,7 @@ TargetBits InstructionSets::Supported() {
   flags |= IsBitSet(abcd[2], 20) ? kBitSSE42 : 0;
   flags |= IsBitSet(abcd[2], 12) ? kBitFMA : 0;
   flags |= IsBitSet(abcd[2], 28) ? kBitAVX : 0;
+  const bool has_xsave = IsBitSet(abcd[2], 26);
   const bool has_osxsave = IsBitSet(abcd[2], 27);
 
   // Extended feature flags
@@ -108,7 +109,7 @@ TargetBits InstructionSets::Supported() {
 
   // Verify OS support for XSAVE, without which XMM/YMM registers are not
   // preserved across context switches and are not safe to use.
-  if (has_osxsave) {
+  if (has_xsave && has_osxsave) {
     const uint32_t xcr0 = ReadXCR0();
     // XMM
     if ((xcr0 & 2) == 0) {
@@ -119,6 +120,9 @@ TargetBits InstructionSets::Supported() {
     if ((xcr0 & 4) == 0) {
       flags &= ~(kBitAVX | kBitAVX2);
     }
+  } else {
+      flags &= ~(kBitSSE | kBitSSE2 | kBitSSE3 | kBitSSSE3 | kBitSSE41 |
+                 kBitSSE42 | kBitAVX | kBitAVX2 | kBitFMA);
   }
 
   // Also indicates "supported" has been initialized.


### PR DESCRIPTION
A Zeek user reported illegal instruction exceptions when running Zeek in a Linux VM (VMware) where /proc/cpuinfo didn't show any avx2 flags, but highwayhash would attempt to use highwayhash::AVX2::HHStateAVX2 regardless.

Their `cpuid` report indicated individual AVX and AVX2 flags being enabled, but OSXSAVE disabled.

    # cpuid | grep XSAVE
    ...
    FXSAVE/FXRSTOR                         = true
    XSAVE/XSTOR states                      = true
    OS-enabled XSAVE/XSTOR                  = false
    ...

Unset the flags if XSAVE is disabled by the OS to prevent using AVX2.